### PR TITLE
Fixed assembly of resource path

### DIFF
--- a/src/test/java/net/lingala/zip4j/TestUtils.java
+++ b/src/test/java/net/lingala/zip4j/TestUtils.java
@@ -7,12 +7,8 @@ public class TestUtils {
   private static final String TEST_FILES_FOLDER_NAME = "test-files";
 
   public static File getFileFromResources(String fileName) {
-    return new File(TestUtils.class.getResource(
-        System.getProperty("file.separator")
-            + TEST_FILES_FOLDER_NAME
-            + System.getProperty("file.separator")
-            + fileName)
-        .getFile());
+    final String path = "/" + TEST_FILES_FOLDER_NAME + "/" + fileName;
+    return new File(TestUtils.class.getResource(path).getFile());
   }
 
 }


### PR DESCRIPTION
Fixed an issue that prevented tests to be executed on Windows hosts.

[Official documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/lang/resources.html) states that "the name of a resource is a "/"-separated sequence of identifiers".
I therefore replaced the OS specific separator with the default one.