### PR TITLE
Skip to the next entry when ignoring __MACOSX files

### DIFF
--- a/src/main/java/net/lingala/zip4j/tasks/ExtractAllFilesTask.java
+++ b/src/main/java/net/lingala/zip4j/tasks/ExtractAllFilesTask.java
@@ -28,6 +28,7 @@ public class ExtractAllFilesTask extends AbstractExtractFileTask<ExtractAllFiles
       for (FileHeader fileHeader : getZipModel().getCentralDirectory().getFileHeaders()) {
         if (fileHeader.getFileName().startsWith("__MACOSX")) {
           progressMonitor.updateWorkCompleted(fileHeader.getUncompressedSize());
+          zipInputStream.getNextEntry();
           continue;
         }
 


### PR DESCRIPTION
Not skipping results in a mismatch between the names of the current entry
and the current file, throwing an exception in
AbstractExtractFileTask.verifyNextEntry().