### PR TITLE
Fix encoding warnings on maven package build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <assertj.version>3.12.2</assertj.version>
         <mockito.version>1.10.19</mockito.version>
         <powermock.version>1.6.6</powermock.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
When building with maven the following warning was issued multiple times:
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
Setting the encoding hard to UTF-8 fixes it.