### PR TITLE
fix for unit tests failure on Windows

### DIFF
--- a/src/test/java/net/lingala/zip4j/util/FileUtilsTest.java
+++ b/src/test/java/net/lingala/zip4j/util/FileUtilsTest.java
@@ -157,14 +157,18 @@ public class FileUtilsTest {
 
   @Test
   public void testGetZipFileNameWithoutExtensionForWindowsFileSeparator() throws ZipException {
+    final String ACTUAL_FILE_SEPARATOR = System.getProperty("file.separator");
     System.setProperty("file.separator", "\\");
     assertThat(FileUtils.getZipFileNameWithoutExtension("c:\\mydir\\somefile.zip")).isEqualTo("somefile");
+    System.setProperty("file.separator", ACTUAL_FILE_SEPARATOR);
   }
 
   @Test
   public void testGetZipFileNameWithoutExtensionForUnixFileSeparator() throws ZipException {
+    final String ACTUAL_FILE_SEPARATOR = System.getProperty("file.separator");
     System.setProperty("file.separator", "/");
     assertThat(FileUtils.getZipFileNameWithoutExtension("/usr/srikanth/somezip.zip")).isEqualTo("somezip");
+    System.setProperty("file.separator", ACTUAL_FILE_SEPARATOR);
   }
 
   @Test
@@ -223,7 +227,8 @@ public class FileUtilsTest {
 
   @Test
   public void testGetSplitZipFilesReturnsValidWhenSplitFile() throws ZipException {
-    String path = "/usr/parentdir/";
+    final String FILE_SEPARATOR = System.getProperty("file.separator");
+    String path = FILE_SEPARATOR + "usr" + FILE_SEPARATOR + "parentdir" + FILE_SEPARATOR;
     String zipFileName = "SomeName";
     File zipFile = mockZipFileAsExists(path, zipFileName);
     ZipModel zipModel = new ZipModel();


### PR DESCRIPTION
The test case `testGetSplitZipFilesReturnsValidWhenSplitFile` is failed on Windows.
It's because that `path` is using "/usr/parentdir/" ignoring the `file.separator` of the operating system. On Linux or Mac, this test case is OK because the `file.separator` is '/', while it's '\' on Windows.
And some test cases has changed the `file.separator` and didn't change them back. This should also be fixed.