### PR TITLE
testcase fix

### DIFF
--- a/src/test/java/net/lingala/zip4j/MiscZipFileIT.java
+++ b/src/test/java/net/lingala/zip4j/MiscZipFileIT.java
@@ -384,6 +384,11 @@ public class MiscZipFileIT extends AbstractIT {
     File newFile = temporaryFolder.newFile("NEW_FILE_NAME.ZIP");
     String oldFile = generatedZipFile.getPath();
 
+    if(TestUtils.isWindows())
+    {
+      newFile.delete();
+    }
+
     assertThat(generatedZipFile.renameTo(newFile)).isTrue();
     assertThat(new File(oldFile)).doesNotExist();
   }

--- a/src/test/java/net/lingala/zip4j/testutils/TestUtils.java
+++ b/src/test/java/net/lingala/zip4j/testutils/TestUtils.java
@@ -18,6 +18,11 @@ public class TestUtils {
    return getFileFromResources(TEST_ARCHIVES_FOLDER_NAME, fileName);
   }
 
+  public static Boolean isWindows() {
+    String os = System.getProperty("os.name").toLowerCase();
+    return (os.contains("win"));
+  }
+
   private static File getFileFromResources(String parentFolder, String fileName) {
     try {
       String path = "/" + parentFolder + "/" + fileName;


### PR DESCRIPTION
Testcase `testRenameZipFileAfterExtractionWithInputStreamSucceeds` would fail on Windows. This is because the `renameTo` would return fail if the target exists, while it would work successfully on Linux/MacOS even if the target exists.
Therefore the `newFile` need to be deleted on Windows, otherwise the `generatedZipFile.renameTo(newFile)` will return false and this testcase would fail.
for reference:
[javadoc](https://docs.oracle.com/javase/6/docs/api/java/io/File.html#renameTo%28java.io.File%29)
[file-renameto-fails](https://stackoverflow.com/questions/13826045/file-renameto-fails)