### PR TITLE
fix: maven test command doesn't execute all testcases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,27 @@
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.maven.surefire</groupId>
+                        <artifactId>surefire-junit47</artifactId>
+                        <version>2.19</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <includes>
+                        <include>**/Test*.java</include>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                        <include>**/*TestCase.java</include>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
The default configuration for `maven test` is to test java classes named like `*Test.java`, `Test*.java`,  `*Tests.java` or  `*Testcase.java`. But some test classes are named like `*IT.java`. Therefore these testcases would not be excuted with maven command `mvn test`.
This PR is to fix this error by adding configuration for `maven-surefire-plugin`.