### PR TITLE
replaced java.nio.charset.StandardCharsets with clone from openjdk

### DIFF
--- a/src/main/java/net/lingala/zip4j/headers/FileHeaderFactory.java
+++ b/src/main/java/net/lingala/zip4j/headers/FileHeaderFactory.java
@@ -12,7 +12,7 @@ import net.lingala.zip4j.model.enums.EncryptionMethod;
 import net.lingala.zip4j.util.Zip4jUtil;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 
 import static net.lingala.zip4j.util.BitUtils.setBit;
 import static net.lingala.zip4j.util.BitUtils.unsetBit;

--- a/src/main/java/net/lingala/zip4j/headers/HeaderReader.java
+++ b/src/main/java/net/lingala/zip4j/headers/HeaderReader.java
@@ -40,7 +40,7 @@ import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/net/lingala/zip4j/headers/HeaderUtil.java
+++ b/src/main/java/net/lingala/zip4j/headers/HeaderUtil.java
@@ -6,7 +6,7 @@ import net.lingala.zip4j.model.ZipModel;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 import java.util.List;
 
 import static net.lingala.zip4j.util.InternalZipConstants.ZIP_STANDARD_CHARSET;

--- a/src/main/java/net/lingala/zip4j/headers/HeaderWriter.java
+++ b/src/main/java/net/lingala/zip4j/headers/HeaderWriter.java
@@ -33,7 +33,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 import java.util.List;
 
 import static net.lingala.zip4j.util.FileUtils.getZipFileNameWithoutExtension;

--- a/src/main/java/net/lingala/zip4j/io/inputstream/ZipInputStream.java
+++ b/src/main/java/net/lingala/zip4j/io/inputstream/ZipInputStream.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PushbackInputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 import java.util.List;
 import java.util.zip.CRC32;
 import java.util.zip.DataFormatException;

--- a/src/main/java/net/lingala/zip4j/io/outputstream/ZipOutputStream.java
+++ b/src/main/java/net/lingala/zip4j/io/outputstream/ZipOutputStream.java
@@ -16,7 +16,7 @@ import net.lingala.zip4j.util.RawIO;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 import java.util.zip.CRC32;
 
 public class ZipOutputStream extends OutputStream {

--- a/src/main/java/net/lingala/zip4j/util/StandardCharsets.java
+++ b/src/main/java/net/lingala/zip4j/util/StandardCharsets.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package net.lingala.zip4j.util;
+
+import java.nio.charset.Charset;
+
+/**
+ * Constant definitions for the standard {@link Charset Charsets}. These
+ * charsets are guaranteed to be available on every implementation of the Java
+ * platform.
+ *
+ * @see <a href="Charset#standard">Standard Charsets</a>
+ * @since 1.7
+ */
+public final class StandardCharsets {
+
+    private StandardCharsets() {
+        throw new AssertionError("No net.lingala.zip4j.util.StandardCharsets instances for you!");
+    }
+    /**
+     * Seven-bit ASCII, a.k.a. ISO646-US, a.k.a. the Basic Latin block of the
+     * Unicode character set
+     */
+    public static final Charset US_ASCII = Charset.forName("US-ASCII");
+    /**
+     * ISO Latin Alphabet No. 1, a.k.a. ISO-LATIN-1
+     */
+    public static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
+    /**
+     * Eight-bit UCS Transformation Format
+     */
+    public static final Charset UTF_8 = Charset.forName("UTF-8");
+    /**
+     * Sixteen-bit UCS Transformation Format, big-endian byte order
+     */
+    public static final Charset UTF_16BE = Charset.forName("UTF-16BE");
+    /**
+     * Sixteen-bit UCS Transformation Format, little-endian byte order
+     */
+    public static final Charset UTF_16LE = Charset.forName("UTF-16LE");
+    /**
+     * Sixteen-bit UCS Transformation Format, byte order identified by an
+     * optional byte-order mark
+     */
+    public static final Charset UTF_16 = Charset.forName("UTF-16");
+}

--- a/src/test/java/net/lingala/zip4j/ZipFileZip64IT.java
+++ b/src/test/java/net/lingala/zip4j/ZipFileZip64IT.java
@@ -17,7 +17,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/net/lingala/zip4j/headers/FileHeaderFactoryTest.java
+++ b/src/test/java/net/lingala/zip4j/headers/FileHeaderFactoryTest.java
@@ -15,7 +15,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 
 import static net.lingala.zip4j.util.BitUtils.isBitSet;
 import static net.lingala.zip4j.util.Zip4jUtil.javaToDosTime;

--- a/src/test/java/net/lingala/zip4j/headers/HeaderReaderIT.java
+++ b/src/test/java/net/lingala/zip4j/headers/HeaderReaderIT.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/test/java/net/lingala/zip4j/headers/HeaderUtilTest.java
+++ b/src/test/java/net/lingala/zip4j/headers/HeaderUtilTest.java
@@ -10,7 +10,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/net/lingala/zip4j/headers/HeaderWriterIT.java
+++ b/src/test/java/net/lingala/zip4j/headers/HeaderWriterIT.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/test/java/net/lingala/zip4j/io/outputstream/ZipOutputStreamIT.java
+++ b/src/test/java/net/lingala/zip4j/io/outputstream/ZipOutputStreamIT.java
@@ -20,7 +20,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/test/java/net/lingala/zip4j/testutils/TestUtils.java
+++ b/src/test/java/net/lingala/zip4j/testutils/TestUtils.java
@@ -3,7 +3,7 @@ package net.lingala.zip4j.testutils;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 
 public class TestUtils {
 

--- a/src/test/java/net/lingala/zip4j/testutils/ZipFileVerifier.java
+++ b/src/test/java/net/lingala/zip4j/testutils/ZipFileVerifier.java
@@ -8,7 +8,7 @@ import net.lingala.zip4j.util.FileUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import net.lingala.zip4j.util.StandardCharsets;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
Related to issue #78 in regards to `java.nio.charset.StandardCharsets` forcing to bump Android level to 19 or later - since the the class is just a list of a few constants, it could make sense to just copy paste the `StandardCharsets` class from openjdk