### PR TITLE
Rename file in zip

### DIFF
--- a/src/main/java/net/lingala/zip4j/ZipFile.java
+++ b/src/main/java/net/lingala/zip4j/ZipFile.java
@@ -683,6 +683,38 @@ public class ZipFile {
   }
 
   /**
+   * Rename the file provided in the input parameters.
+   * This method first finds the file header and then renames the file.
+   * If file does not exist, then this method throws an exception.
+   * If zip file is a split zip file, then this method throws an exception as
+   * zip specification does not allow for updating split zip archives.
+   *
+   * @param fileName
+   * @param newFileName
+   * @throws ZipException
+   */
+  public void renameFile(String fileName, String newFileName) throws ZipException {
+    if (!isStringNotNullAndNotEmpty(fileName)) {
+      throw new ZipException("file name is empty or null, cannot rename file");
+    }
+
+    if (zipModel == null) {
+      readZipInfo();
+    }
+
+    if (zipModel.isSplitArchive()) {
+      throw new ZipException("Zip file format does not allow updating split/spanned files");
+    }
+
+    FileHeader fileHeader = HeaderUtil.getFileHeader(zipModel, fileName);
+    if (fileHeader == null) {
+      throw new ZipException("could not find file header for file: " + fileName);
+    }
+
+    renameFile(fileHeader, newFileName);
+  }
+
+  /**
    * Rename the file provided in the input file header from the zip file.
    * If zip file is a split zip file, then this method throws an exception as
    * zip specification does not allow for updating split zip archives.

--- a/src/main/java/net/lingala/zip4j/ZipFile.java
+++ b/src/main/java/net/lingala/zip4j/ZipFile.java
@@ -40,6 +40,8 @@ import net.lingala.zip4j.tasks.MergeSplitZipFileTask;
 import net.lingala.zip4j.tasks.MergeSplitZipFileTask.MergeSplitZipFileTaskParameters;
 import net.lingala.zip4j.tasks.RemoveEntryFromZipFileTask;
 import net.lingala.zip4j.tasks.RemoveEntryFromZipFileTask.RemoveEntryFromZipFileTaskParameters;
+import net.lingala.zip4j.tasks.RenameFileInZipTask;
+import net.lingala.zip4j.tasks.RenameFileInZipTask.RenameFileInZipTaskParameters;
 import net.lingala.zip4j.tasks.SetCommentTask;
 import net.lingala.zip4j.tasks.SetCommentTask.SetCommentTaskTaskParameters;
 import net.lingala.zip4j.util.FileUtils;
@@ -678,6 +680,32 @@ public class ZipFile {
 
     new RemoveEntryFromZipFileTask(progressMonitor, runInThread, zipModel).execute(
             new RemoveEntryFromZipFileTaskParameters(fileHeader, charset));
+  }
+
+  /**
+   * Rename the file provided in the input file header from the zip file.
+   * If zip file is a split zip file, then this method throws an exception as
+   * zip specification does not allow for updating split zip archives.
+   *
+   * @param fileHeader
+   * @param newFileName
+   * @throws ZipException
+   */
+  public void renameFile(FileHeader fileHeader, String newFileName) throws ZipException {
+    if (fileHeader == null) {
+      throw new ZipException("input file header is null, cannot rename file");
+    }
+
+    if (zipModel == null) {
+      readZipInfo();
+    }
+
+    if (zipModel.isSplitArchive()) {
+      throw new ZipException("Zip file format does not allow updating split/spanned files");
+    }
+
+    new RenameFileInZipTask(progressMonitor, runInThread, zipModel).execute(
+            new RenameFileInZipTask.RenameFileInZipTaskParameters(fileHeader, newFileName, charset));
   }
 
   /**

--- a/src/main/java/net/lingala/zip4j/progress/ProgressMonitor.java
+++ b/src/main/java/net/lingala/zip4j/progress/ProgressMonitor.java
@@ -23,7 +23,7 @@ public class ProgressMonitor {
 
   public enum State { READY, BUSY }
   public enum Result { SUCCESS, WORK_IN_PROGRESS, ERROR, CANCELLED }
-  public enum Task { NONE, ADD_ENTRY, REMOVE_ENTRY, CALCULATE_CRC, EXTRACT_ENTRY, MERGE_ZIP_FILES, SET_COMMENT}
+  public enum Task { NONE, ADD_ENTRY, REMOVE_ENTRY, CALCULATE_CRC, EXTRACT_ENTRY, MERGE_ZIP_FILES, SET_COMMENT, RENAME_FILE}
 
   private State state;
   private long totalWork;

--- a/src/main/java/net/lingala/zip4j/tasks/AbstractModifyFileTask.java
+++ b/src/main/java/net/lingala/zip4j/tasks/AbstractModifyFileTask.java
@@ -1,0 +1,65 @@
+package net.lingala.zip4j.tasks;
+
+import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.model.FileHeader;
+import net.lingala.zip4j.model.ZipModel;
+import net.lingala.zip4j.progress.ProgressMonitor;
+
+import java.io.File;
+import java.util.Random;
+
+public abstract class AbstractModifyFileTask<T> extends AsyncZipTask<T> {
+  public AbstractModifyFileTask(ProgressMonitor progressMonitor, boolean runInThread) {
+    super(progressMonitor, runInThread);
+  }
+
+  File getTemporaryFile(String zipPathWithName) {
+    Random random = new Random();
+    File tmpFile = new File(zipPathWithName + random.nextInt(10000));
+
+    while (tmpFile.exists()) {
+      tmpFile = new File(zipPathWithName + random.nextInt(10000));
+    }
+
+    return tmpFile;
+  }
+
+  long getOffsetLocalFileHeader(FileHeader fileHeader) {
+    long offsetLocalFileHeader = fileHeader.getOffsetLocalHeader();
+
+    if (fileHeader.getZip64ExtendedInfo() != null && fileHeader.getZip64ExtendedInfo().getOffsetLocalHeader() != -1) {
+      offsetLocalFileHeader = fileHeader.getZip64ExtendedInfo().getOffsetLocalHeader();
+    }
+
+    return offsetLocalFileHeader;
+  }
+
+  long getOffsetOfStartOfCentralDirectory(ZipModel zipModel) {
+    long offsetStartCentralDir = zipModel.getEndOfCentralDirectoryRecord().getOffsetOfStartOfCentralDirectory();
+
+    if (zipModel.isZip64Format() && zipModel.getZip64EndOfCentralDirectoryRecord() != null) {
+      offsetStartCentralDir = zipModel.getZip64EndOfCentralDirectoryRecord()
+              .getOffsetStartCentralDirectoryWRTStartDiskNumber();
+    }
+
+    return offsetStartCentralDir;
+  }
+
+  void cleanupFile(boolean successFlag, File zipFile, File temporaryZipFile) throws ZipException {
+    if (successFlag) {
+      restoreFileName(zipFile, temporaryZipFile);
+    } else {
+      temporaryZipFile.delete();
+    }
+  }
+
+  private void restoreFileName(File zipFile, File temporaryZipFile) throws ZipException {
+    if (zipFile.delete()) {
+      if (!temporaryZipFile.renameTo(zipFile)) {
+        throw new ZipException("cannot rename modified zip file");
+      }
+    } else {
+      throw new ZipException("cannot delete old zip file");
+    }
+  }
+}

--- a/src/main/java/net/lingala/zip4j/tasks/RenameFileInZipTask.java
+++ b/src/main/java/net/lingala/zip4j/tasks/RenameFileInZipTask.java
@@ -1,7 +1,6 @@
 package net.lingala.zip4j.tasks;
 
 import net.lingala.zip4j.exception.ZipException;
-import net.lingala.zip4j.headers.FileHeaderFactory;
 import net.lingala.zip4j.headers.HeaderReader;
 import net.lingala.zip4j.headers.HeaderWriter;
 import net.lingala.zip4j.io.outputstream.SplitOutputStream;
@@ -19,13 +18,16 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.Channels;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static net.lingala.zip4j.headers.HeaderUtil.getIndexOfFileHeader;
+import static net.lingala.zip4j.headers.HeaderUtil.getFileHeader;
 
 public class RenameFileInZipTask extends AbstractModifyFileTask<RenameFileInZipTaskParameters> {
   private ZipModel zipModel;
-  private FileHeaderFactory fileHeaderFactory = new FileHeaderFactory();
 
   public RenameFileInZipTask(ProgressMonitor progressMonitor, boolean runInThread, ZipModel zipModel) {
     super(progressMonitor, runInThread);
@@ -43,46 +45,107 @@ public class RenameFileInZipTask extends AbstractModifyFileTask<RenameFileInZipT
       return;
     }
 
+    if(checkIfNewNameIsUsed(taskParameters.newFileName)) {
+      throw new ZipException("The new file name already exists in the zip file.");
+    }
+
     File temporaryZipFile = getTemporaryFile(zipModel.getZipFile().getPath());
     boolean successFlag = false;
 
     try (SplitOutputStream outputStream = new SplitOutputStream(temporaryZipFile);
          RandomAccessFile inputStream = new RandomAccessFile(zipModel.getZipFile(),
                  RandomAccessFileMode.READ.getValue())){
+
       HeaderWriter headerWriter = new HeaderWriter();
-      HeaderReader headerReader = new HeaderReader();
-      int indexOfFileHeader = getIndexOfFileHeader(zipModel, taskParameters.fileHeader);
-      long offsetLocalFileHeader = getOffsetLocalFileHeader(taskParameters.fileHeader);
-      long offsetStartOfCentralDirectory = getOffsetOfStartOfCentralDirectory(zipModel);
-      // read the local file header
-      inputStream.seek(offsetLocalFileHeader);
-      LocalFileHeader localFileHeader = headerReader.readLocalFileHeader(Channels.newInputStream(inputStream.getChannel()), taskParameters.charset);
-      long offsetEndOfLocalFileHeader = getOffsetEndOfLocalFileHeader(offsetLocalFileHeader, localFileHeader);
+      if(!taskParameters.fileHeader.isDirectory()) {
+        Map<FileHeader, Long> localFileHeaderOffsetMap = new HashMap<>();
+        localFileHeaderOffsetMap.put(taskParameters.fileHeader, getOffsetLocalFileHeader(taskParameters.fileHeader));
 
-      int newFileNameLength = taskParameters.newFileName.getBytes(taskParameters.charset).length;
-      // calculate the diff of length in local file header, which is caused by the change of file name
-      int fileNameLengthDiff = newFileNameLength - localFileHeader.getFileNameLength();
-      localFileHeader.setFileName(taskParameters.newFileName);
-      localFileHeader.setFileNameLength(newFileNameLength);
+        writeLocalFileHeaderAndUpdateOffsets(taskParameters.fileHeader, null, localFileHeaderOffsetMap, true,
+                taskParameters.newFileName, taskParameters.charset, outputStream, inputStream, headerWriter, progressMonitor);
+      } else {
+        // if the directory is being renamed, the files in the directory should also be renamed
+        List<FileHeader> fileHeaders = zipModel.getCentralDirectory().getFileHeaders();
+        List<FileHeader> fileHeadersInDirectory = new ArrayList<>();
+        String oldName = taskParameters.fileHeader.getFileName();
 
-      if(indexOfFileHeader > 0) {
-        // copy the content before the changed local file header
-        FileUtils.copyFile(inputStream, outputStream, 0, offsetLocalFileHeader, progressMonitor);
+        Map<FileHeader, Long> localFileHeaderOffsetMap = new HashMap<>();
+        for(FileHeader fileHeader : fileHeaders) {
+          if(fileHeader.getFileName().startsWith(oldName)) {
+            fileHeadersInDirectory.add(fileHeader);
+            // store the local file header offset here as it may mutate after update
+            localFileHeaderOffsetMap.put(fileHeader, getOffsetLocalFileHeader(fileHeader));
+          }
+        }
+
+        for(int i = 0; i < fileHeadersInDirectory.size();i++) {
+          FileHeader fileHeader = fileHeadersInDirectory.get(i);
+          FileHeader nextFileHeader = null;
+          if(i < fileHeadersInDirectory.size() - 1) {
+            nextFileHeader = fileHeadersInDirectory.get(i + 1);
+          }
+
+          boolean isFirstFileHeader = i == 0 ? true : false;
+          String newFileName = fileHeader.getFileName().replaceFirst(oldName, taskParameters.newFileName);
+
+          writeLocalFileHeaderAndUpdateOffsets(fileHeader, nextFileHeader, localFileHeaderOffsetMap, isFirstFileHeader, newFileName,
+                  taskParameters.charset, outputStream, inputStream, headerWriter, progressMonitor);
+        }
       }
 
-      // write the new local file header with new file name
-      headerWriter.writeLocalFileHeader(zipModel, localFileHeader, outputStream, taskParameters.charset);
-
-      // copy the rest of the content in this file, and the data of other files
-      FileUtils.copyFile(inputStream, outputStream, offsetEndOfLocalFileHeader, offsetStartOfCentralDirectory, progressMonitor);
-
-      updateHeaders(outputStream, indexOfFileHeader, taskParameters.newFileName, newFileNameLength, fileNameLengthDiff);
       headerWriter.finalizeZipFile(zipModel, outputStream, taskParameters.charset);
-
       successFlag = true;
     } finally {
       cleanupFile(successFlag, zipModel.getZipFile(), temporaryZipFile);
     }
+  }
+
+  private void writeLocalFileHeaderAndUpdateOffsets(FileHeader fileHeader, FileHeader nextFileHeader, Map<FileHeader, Long> localFileHeaderOffsetMap, boolean isFirstHeader, String newFileName, Charset charset,
+                                                    SplitOutputStream outputStream, RandomAccessFile inputStream, HeaderWriter headerWriter, ProgressMonitor progressMonitor) throws IOException {
+    HeaderReader headerReader = new HeaderReader();
+    int indexOfFileHeader = getIndexOfFileHeader(zipModel, fileHeader);
+    long offsetLocalFileHeader = localFileHeaderOffsetMap.get(fileHeader);
+    inputStream.seek(offsetLocalFileHeader);
+    LocalFileHeader localFileHeader = headerReader.readLocalFileHeader(Channels.newInputStream(inputStream.getChannel()), charset);
+    long offsetEndOfLocalFileHeader = getOffsetEndOfLocalFileHeader(offsetLocalFileHeader, localFileHeader);
+
+    int newFileNameLength = newFileName.getBytes(charset).length;
+    // calculate the diff of length in local file header, which is caused by the change of file name
+    int fileNameLengthDiff = newFileNameLength - localFileHeader.getFileNameLength();
+    localFileHeader.setFileName(newFileName);
+    localFileHeader.setFileNameLength(newFileNameLength);
+
+    if(isFirstHeader && indexOfFileHeader > 0) {
+      // copy the content before the changed local file header
+      FileUtils.copyFile(inputStream, outputStream, 0, offsetLocalFileHeader, progressMonitor);
+    }
+
+    // write the new local file header with new file name
+    headerWriter.writeLocalFileHeader(zipModel, localFileHeader, outputStream, charset);
+
+    // copy the rest of the content in this file, and the data of other files
+    long writeEndOffset;
+    if(nextFileHeader == null) {
+      writeEndOffset = getOffsetOfStartOfCentralDirectory(zipModel);
+    } else {
+      writeEndOffset = localFileHeaderOffsetMap.get(nextFileHeader);
+    }
+    FileUtils.copyFile(inputStream, outputStream, offsetEndOfLocalFileHeader, writeEndOffset, progressMonitor);
+
+    if(nextFileHeader == null) {
+      // update the offset of start of central directory when finish writing all headers
+      updateEndOfCentralDirectoryRecord(outputStream);
+    }
+    updateHeaders(indexOfFileHeader, newFileName, newFileNameLength, fileNameLengthDiff);
+  }
+
+  private boolean checkIfNewNameIsUsed(String newFileName) throws ZipException {
+    FileHeader fileHeader = getFileHeader(zipModel, newFileName);
+    if(fileHeader != null) {
+      return true;
+    }
+
+    return false;
   }
 
   /**
@@ -113,21 +176,19 @@ public class RenameFileInZipTask extends AbstractModifyFileTask<RenameFileInZipT
    * the file name and file name length in central directory header should be changed accordingly,
    * the offset of the offset of start of central directory should be changed accordingly
    * the offset of the files after the changed file should be changed accordingly
-   * @param splitOutputStream
    * @param indexOfFileHeader
    * @param newFileName
    * @param newFileNameLength
    * @param fileNameLengthDiff
    * @throws IOException
    */
-  private void updateHeaders(SplitOutputStream splitOutputStream, int indexOfFileHeader, String newFileName,
+  private void updateHeaders(int indexOfFileHeader, String newFileName,
                              int newFileNameLength, int fileNameLengthDiff) throws IOException {
     FileHeader fileHeader = zipModel.getCentralDirectory().getFileHeaders().get(indexOfFileHeader);
     fileHeader.setFileName(newFileName);
     fileHeader.setFileNameLength(newFileNameLength);
     if(fileNameLengthDiff != 0) {
       // no need to update the offsets if the length of 2 file names are same
-      updateEndOfCentralDirectoryRecord(splitOutputStream);
       updateFileHeadersWithLocalHeaderOffsets(zipModel.getCentralDirectory().getFileHeaders(), fileNameLengthDiff, indexOfFileHeader);
     }
   }

--- a/src/main/java/net/lingala/zip4j/tasks/RenameFileInZipTask.java
+++ b/src/main/java/net/lingala/zip4j/tasks/RenameFileInZipTask.java
@@ -1,0 +1,184 @@
+package net.lingala.zip4j.tasks;
+
+import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.headers.FileHeaderFactory;
+import net.lingala.zip4j.headers.HeaderReader;
+import net.lingala.zip4j.headers.HeaderWriter;
+import net.lingala.zip4j.io.outputstream.SplitOutputStream;
+import net.lingala.zip4j.model.EndOfCentralDirectoryRecord;
+import net.lingala.zip4j.model.FileHeader;
+import net.lingala.zip4j.model.LocalFileHeader;
+import net.lingala.zip4j.model.ZipModel;
+import net.lingala.zip4j.model.enums.RandomAccessFileMode;
+import net.lingala.zip4j.progress.ProgressMonitor;
+import net.lingala.zip4j.tasks.RenameFileInZipTask.RenameFileInZipTaskParameters;
+import net.lingala.zip4j.util.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.channels.Channels;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import static net.lingala.zip4j.headers.HeaderUtil.getIndexOfFileHeader;
+
+public class RenameFileInZipTask extends AbstractModifyFileTask<RenameFileInZipTaskParameters> {
+  private ZipModel zipModel;
+  private FileHeaderFactory fileHeaderFactory = new FileHeaderFactory();
+
+  public RenameFileInZipTask(ProgressMonitor progressMonitor, boolean runInThread, ZipModel zipModel) {
+    super(progressMonitor, runInThread);
+    this.zipModel = zipModel;
+  }
+
+  @Override
+  protected void executeTask(RenameFileInZipTaskParameters taskParameters, ProgressMonitor progressMonitor) throws IOException {
+    if (zipModel.isSplitArchive()) {
+      throw new ZipException("This is a split archive. Zip file format does not allow updating split/spanned files");
+    }
+
+    // no need to update file name if they are the same
+    if(taskParameters.newFileName.equalsIgnoreCase(taskParameters.fileHeader.getFileName())) {
+      return;
+    }
+
+    File temporaryZipFile = getTemporaryFile(zipModel.getZipFile().getPath());
+    boolean successFlag = false;
+
+    try (SplitOutputStream outputStream = new SplitOutputStream(temporaryZipFile);
+         RandomAccessFile inputStream = new RandomAccessFile(zipModel.getZipFile(),
+                 RandomAccessFileMode.READ.getValue())){
+      HeaderWriter headerWriter = new HeaderWriter();
+      HeaderReader headerReader = new HeaderReader();
+      int indexOfFileHeader = getIndexOfFileHeader(zipModel, taskParameters.fileHeader);
+      long offsetLocalFileHeader = getOffsetLocalFileHeader(taskParameters.fileHeader);
+      long offsetStartOfCentralDirectory = getOffsetOfStartOfCentralDirectory(zipModel);
+      // read the local file header
+      inputStream.seek(offsetLocalFileHeader);
+      LocalFileHeader localFileHeader = headerReader.readLocalFileHeader(Channels.newInputStream(inputStream.getChannel()), taskParameters.charset);
+      long offsetEndOfLocalFileHeader = getOffsetEndOfLocalFileHeader(offsetLocalFileHeader, localFileHeader);
+
+      int newFileNameLength = taskParameters.newFileName.getBytes(taskParameters.charset).length;
+      // calculate the diff of length in local file header, which is caused by the change of file name
+      int fileNameLengthDiff = newFileNameLength - localFileHeader.getFileNameLength();
+      localFileHeader.setFileName(taskParameters.newFileName);
+      localFileHeader.setFileNameLength(newFileNameLength);
+
+      if(indexOfFileHeader > 0) {
+        // copy the content before the changed local file header
+        FileUtils.copyFile(inputStream, outputStream, 0, offsetLocalFileHeader, progressMonitor);
+      }
+
+      // write the new local file header with new file name
+      headerWriter.writeLocalFileHeader(zipModel, localFileHeader, outputStream, taskParameters.charset);
+
+      // copy the rest of the content in this file, and the data of other files
+      FileUtils.copyFile(inputStream, outputStream, offsetEndOfLocalFileHeader, offsetStartOfCentralDirectory, progressMonitor);
+
+      updateHeaders(outputStream, indexOfFileHeader, taskParameters.newFileName, newFileNameLength, fileNameLengthDiff);
+      headerWriter.finalizeZipFile(zipModel, outputStream, taskParameters.charset);
+
+      successFlag = true;
+    } finally {
+      cleanupFile(successFlag, zipModel.getZipFile(), temporaryZipFile);
+    }
+  }
+
+  /**
+   * local file header signature     4 bytes  (0x04034b50)
+   * version needed to extract       2 bytes
+   * general purpose bit flag        2 bytes
+   * compression method              2 bytes
+   * last mod file time              2 bytes
+   * last mod file date              2 bytes
+   * crc-32                          4 bytes
+   * compressed size                 4 bytes
+   * uncompressed size               4 bytes
+   * file name length                2 bytes
+   * extra field length              2 bytes
+   *
+   * file name (variable size)
+   * extra field (variable size)
+   *
+   * @param offsetLocalFileHeader
+   * @param localFileHeader
+   * @return
+   */
+  private long getOffsetEndOfLocalFileHeader(long offsetLocalFileHeader, LocalFileHeader localFileHeader) {
+    return offsetLocalFileHeader + 4 + 2 + 2 + 2 + 2 + 2 + 4 + 4 + 4 + 2 + 2 + localFileHeader.getFileNameLength() + localFileHeader.getExtraFieldLength();
+  }
+
+  /**
+   * the file name and file name length in central directory header should be changed accordingly,
+   * the offset of the offset of start of central directory should be changed accordingly
+   * the offset of the files after the changed file should be changed accordingly
+   * @param splitOutputStream
+   * @param indexOfFileHeader
+   * @param newFileName
+   * @param newFileNameLength
+   * @param fileNameLengthDiff
+   * @throws IOException
+   */
+  private void updateHeaders(SplitOutputStream splitOutputStream, int indexOfFileHeader, String newFileName,
+                             int newFileNameLength, int fileNameLengthDiff) throws IOException {
+    FileHeader fileHeader = zipModel.getCentralDirectory().getFileHeaders().get(indexOfFileHeader);
+    fileHeader.setFileName(newFileName);
+    fileHeader.setFileNameLength(newFileNameLength);
+    if(fileNameLengthDiff != 0) {
+      // no need to update the offsets if the length of 2 file names are same
+      updateEndOfCentralDirectoryRecord(splitOutputStream);
+      updateFileHeadersWithLocalHeaderOffsets(zipModel.getCentralDirectory().getFileHeaders(), fileNameLengthDiff, indexOfFileHeader);
+    }
+  }
+
+  /**
+   * the offset of the offset of start of central directory should be changed accordingly
+   * @param splitOutputStream
+   * @throws IOException
+   */
+  private void updateEndOfCentralDirectoryRecord(SplitOutputStream splitOutputStream) throws IOException {
+    EndOfCentralDirectoryRecord endOfCentralDirectoryRecord = zipModel.getEndOfCentralDirectoryRecord();
+    endOfCentralDirectoryRecord.setOffsetOfStartOfCentralDirectory(splitOutputStream.getFilePointer());
+  }
+
+  /**
+   * the offset of the files after the changed file should be changed accordingly
+   * @param fileHeaders
+   * @param fileNameLengthDiff
+   * @param indexOfFileHeader
+   */
+  private void updateFileHeadersWithLocalHeaderOffsets(List<FileHeader> fileHeaders, int fileNameLengthDiff,
+                                                       int indexOfFileHeader) {
+    for (int i = indexOfFileHeader + 1; i < fileHeaders.size(); i ++) {
+      // for files after the renamed file, the offset should be updated
+      FileHeader fileHeader = fileHeaders.get(i);
+      long offsetLocalHdr = fileHeader.getOffsetLocalHeader();
+      if (fileHeader.getZip64ExtendedInfo() != null && fileHeader.getZip64ExtendedInfo().getOffsetLocalHeader() != -1) {
+        offsetLocalHdr = fileHeader.getZip64ExtendedInfo().getOffsetLocalHeader();
+      }
+      fileHeader.setOffsetLocalHeader(offsetLocalHdr + fileNameLengthDiff);
+    }
+  }
+
+  @Override
+  protected long calculateTotalWork(RenameFileInZipTaskParameters taskParameters) {
+    return zipModel.getZipFile().length();
+  }
+
+  @Override
+  protected ProgressMonitor.Task getTask() {
+    return ProgressMonitor.Task.RENAME_FILE;
+  }
+
+  public static class RenameFileInZipTaskParameters extends AbstractZipTaskParameters {
+    private FileHeader fileHeader;
+    private String newFileName;
+
+    public RenameFileInZipTaskParameters(FileHeader fileHeader, String newFileName, Charset charset) {
+      super(charset);
+      this.fileHeader = fileHeader;
+      this.newFileName = newFileName;
+    }
+  }
+}

--- a/src/test/java/net/lingala/zip4j/RenameFileInZipIT.java
+++ b/src/test/java/net/lingala/zip4j/RenameFileInZipIT.java
@@ -1,0 +1,143 @@
+package net.lingala.zip4j;
+
+import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.model.FileHeader;
+import net.lingala.zip4j.model.ZipParameters;
+import net.lingala.zip4j.testutils.TestUtils;
+import net.lingala.zip4j.testutils.ZipFileVerifier;
+import net.lingala.zip4j.util.InternalZipConstants;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RenameFileInZipIT extends AbstractIT {
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void testRenameFileAsFileNameThrowsExceptionWhenZipFileDoesNotExist() throws ZipException {
+    String fileNameToRename = "SOME_NAME";
+    expectedException.expect(ZipException.class);
+    expectedException.expectMessage("could not find file header for file: " + fileNameToRename);
+
+    new ZipFile(generatedZipFile).renameFile(fileNameToRename, "NEW_NAME");
+  }
+
+  @Test
+  public void testRenameFileAsFileNameThrowsExceptionWhenFileDoesNotExistInZip() throws ZipException {
+    String fileNameToRename = "SOME_NAME";
+    expectedException.expect(ZipException.class);
+    expectedException.expectMessage("could not find file header for file: " + fileNameToRename);
+
+    ZipFile zipFile = new ZipFile(generatedZipFile);
+    zipFile.addFiles(FILES_TO_ADD);
+
+    zipFile.renameFile(fileNameToRename, "NEW_NAME");
+  }
+
+  @Test
+  public void testRenameFileAsFileNameThrowsExceptionWhenFileAlreadyExistInZip() throws ZipException {
+    String fileNameToRename = "sample_text1.txt";
+    expectedException.expect(ZipException.class);
+    expectedException.expectMessage("The new file name already exists in the zip file.");
+
+    ZipFile zipFile = new ZipFile(generatedZipFile);
+    zipFile.addFiles(FILES_TO_ADD);
+
+    zipFile.renameFile(fileNameToRename, "sample.pdf");
+  }
+
+  @Test
+  public void testRenameFileAsFileNameThrowsExceptionForSplitArchive() throws ZipException {
+    ZipFile zipFile = new ZipFile(generatedZipFile);
+    List<File> filesToAdd = new ArrayList<>(FILES_TO_ADD);
+    filesToAdd.add(TestUtils.getTestFileFromResources("file_PDF_1MB.pdf"));
+    zipFile.createSplitZipFile(filesToAdd, new ZipParameters(), true, InternalZipConstants.MIN_SPLIT_LENGTH);
+
+    expectedException.expect(ZipException.class);
+    expectedException.expectMessage("Zip file format does not allow updating split/spanned files");
+
+    zipFile.renameFile("file_PDF_1MB.pdf", "NEW_NAME");
+  }
+
+  @Test
+  public void testRenameFileAsFileNameSuccessfully() throws IOException {
+    ZipFile zipFile = new ZipFile(generatedZipFile);
+    zipFile.addFiles(FILES_TO_ADD);
+    String oldName = "sample_text1.txt";
+    String newName = "NEW_NAME.txt";
+
+    zipFile.renameFile(oldName, newName);
+
+    ZipFileVerifier.verifyZipFileByExtractingAllFiles(generatedZipFile, null, outputFolder, 3, false);
+    verifyZipFileDoesNotContainFile(generatedZipFile, "sample_text1.txt", null);
+    verifyZipFileContainFile(generatedZipFile, "NEW_NAME.txt", null);
+    verifyRenamedFileContentByExtractingFile(generatedZipFile, outputFolder, oldName, newName);
+  }
+
+  @Test
+  public void testRenameFileAsFileNameWithCharsetCp949Successfully() throws IOException {
+    ZipFile zipFile = new ZipFile(generatedZipFile);
+    zipFile.setCharset(CHARSET_CP_949);
+
+    List<File> filesToAdd = new ArrayList<>();
+    filesToAdd.add(TestUtils.getTestFileFromResources("sample_text1.txt"));
+    zipFile.addFiles(filesToAdd);
+
+    zipFile.renameFile("sample_text1.txt", "가나다.abc");
+
+    verifyZipFileContainFile(generatedZipFile, "가나다.abc", CHARSET_CP_949);
+  }
+
+  @Test
+  public void testRenameFolderSuccessfully() throws IOException {
+    ZipFile zipFile = new ZipFile(generatedZipFile);
+    zipFile.addFolder(TestUtils.getTestFileFromResources(""));
+    String oldName = "test-files/öüäöäö/";
+    String newName = "NEW_NAME/";
+
+    zipFile.renameFile(oldName, newName);
+
+    ZipFileVerifier.verifyZipFileByExtractingAllFiles(generatedZipFile, null, outputFolder, 13, false);
+    verifyZipFileDoesNotContainFile(generatedZipFile, "test-files/öüäöäö/asöäööl", null);
+    verifyZipFileContainFile(generatedZipFile, "NEW_NAME/asöäööl", null);
+    verifyRenamedFileContentByExtractingFile(generatedZipFile, outputFolder, "öüäöäö/asöäööl", "NEW_NAME/asöäööl");
+  }
+
+  private void verifyRenamedFileContentByExtractingFile(File zipFileToExtract, File outputFolder, String oldFileName, String newFileName) throws IOException {
+    ZipFile zipFile = new ZipFile(zipFileToExtract);
+    zipFile.extractFile(newFileName, outputFolder.getAbsolutePath());
+    File fileWithNewName = new File(outputFolder.getAbsolutePath() + InternalZipConstants.FILE_SEPARATOR + newFileName);
+    File originalFile = TestUtils.getTestFileFromResources(oldFileName);
+    ZipFileVerifier.verifyFileContent(fileWithNewName, originalFile);
+  }
+
+  private void verifyZipFileDoesNotContainFile(File generatedZipFile, String fileNameToCheck, Charset charset) throws ZipException {
+    ZipFile zipFile = new ZipFile(generatedZipFile);
+    if(charset != null) {
+      zipFile.setCharset(charset);
+    }
+    Optional<FileHeader> fileHeader = zipFile.getFileHeaders().stream()
+            .filter(e -> e.getFileName().equals(fileNameToCheck)).findFirst();
+    assertThat(fileHeader).isNotPresent();
+  }
+
+  private void verifyZipFileContainFile(File generatedZipFile, String fileNameToCheck, Charset charset) throws ZipException {
+    ZipFile zipFile = new ZipFile(generatedZipFile);
+    if(charset != null) {
+      zipFile.setCharset(charset);
+    }
+    Optional<FileHeader> fileHeader = zipFile.getFileHeaders().stream()
+            .filter(e -> e.getFileName().equals(fileNameToCheck)).findFirst();
+    assertThat(fileHeader).isPresent();
+  }
+}


### PR DESCRIPTION
[#72](https://github.com/srikanth-lingala/zip4j/issues/72)
Add the feature of renaming a file in ZipFile.

If zip file is a split zip file, a exception will be thrown.
If the new name already exists in the zip file, a exception will be thrown.

This feature can work when renaming a directory. The files in the directory will also be renamed accordingly.

Use implemention of `RemoveEntryFromZipFileTask` as reference. Implemented by copying the content before the local file header to be renamed, then write the local file header by `HeaderWriter.writeLocalFileHeader` , then copy the rest of the renamed file(e.g. encryption header, file data, data descriptor) and other files data. In the end, update the central directory headers and write data via `headerWriter.finalizeZipFile`.