### PR TITLE
Add unit tests for net.lingala.zip4j.crypto.PBKDF2.BinTools

### DIFF
--- a/src/test/java/net/lingala/zip4j/crypto/PBKDF2/BinToolsTest.java
+++ b/src/test/java/net/lingala/zip4j/crypto/PBKDF2/BinToolsTest.java
@@ -1,0 +1,65 @@
+package net.lingala.zip4j.crypto.PBKDF2;
+
+import java.lang.reflect.Array;
+import net.lingala.zip4j.crypto.PBKDF2.BinTools;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+
+public class BinToolsTest {
+  @Rule
+  public final Timeout globalTimeout = new Timeout(10000);
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void bin2hexInput1OutputNotNull2() {
+    final byte[] b = {(byte) 112};
+    Assert.assertEquals("70", BinTools.bin2hex(b));
+  }
+
+  @Test
+  public void bin2hexInput0OutputNotNull() {
+    final byte[] b = {};
+    Assert.assertEquals("", BinTools.bin2hex(b));
+  }
+
+  @Test
+  public void bin2hexInputNullOutputNotNull() {
+    Assert.assertEquals("", BinTools.bin2hex(null));
+  }
+
+  @Test
+  public void hex2binInputNullOutput0() {
+    final String s = null;
+    final byte[] actual = BinTools.hex2bin(s);
+    Assert.assertArrayEquals(new byte[]{}, actual);
+  }
+
+  @Test
+  public void hex2binInputNotNullOutputIllegalArgumentException3() {
+    final String s = "foo";
+    thrown.expect(IllegalArgumentException.class);
+    BinTools.hex2bin(s);
+  }
+
+  @Test
+  public void hex2binInputAOutputPositive() {
+    Assert.assertEquals(10, BinTools.hex2bin('A'));
+  }
+
+  @Test
+  public void hex2binInputNotNullOutputIllegalArgumentException2() {
+    thrown.expect(IllegalArgumentException.class);
+    BinTools.hex2bin('\u013c');
+  }
+
+  @Test
+  public void hex2binInputNotNullOutputIllegalArgumentException() {
+    thrown.expect(IllegalArgumentException.class);
+    BinTools.hex2bin('\u0018');
+  }
+}

--- a/src/test/java/net/lingala/zip4j/crypto/PBKDF2/BinToolsTest.java
+++ b/src/test/java/net/lingala/zip4j/crypto/PBKDF2/BinToolsTest.java
@@ -1,65 +1,52 @@
 package net.lingala.zip4j.crypto.PBKDF2;
 
-import java.lang.reflect.Array;
-import net.lingala.zip4j.crypto.PBKDF2.BinTools;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BinToolsTest {
-  @Rule
-  public final Timeout globalTimeout = new Timeout(10000);
 
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void bin2hexInput1OutputNotNull2() {
+  public void bin2hexForValidInputReturnsValidHex() {
     final byte[] b = {(byte) 112};
-    Assert.assertEquals("70", BinTools.bin2hex(b));
+    assertThat(BinTools.bin2hex(b)).isEqualTo("70");
   }
 
   @Test
-  public void bin2hexInput0OutputNotNull() {
-    final byte[] b = {};
-    Assert.assertEquals("", BinTools.bin2hex(b));
+  public void bin2hexForEmptyInputReturnsEmptyString() {
+    assertThat(BinTools.bin2hex(new byte[]{})).isEqualTo("");
   }
 
   @Test
-  public void bin2hexInputNullOutputNotNull() {
-    Assert.assertEquals("", BinTools.bin2hex(null));
+  public void bin2hexForNullInputReturnsEmptyString() {
+    assertThat(BinTools.bin2hex(null)).isEqualTo("");
   }
 
   @Test
-  public void hex2binInputNullOutput0() {
+  public void bin2hexForNullInputReturnsEmptyArray() {
     final String s = null;
-    final byte[] actual = BinTools.hex2bin(s);
-    Assert.assertArrayEquals(new byte[]{}, actual);
+    assertThat(BinTools.hex2bin(s)).isEqualTo(new byte[]{});
   }
 
   @Test
-  public void hex2binInputNotNullOutputIllegalArgumentException3() {
-    final String s = "foo";
+  public void hex2binForInvalidInputOutputIllegalArgumentException() {
     thrown.expect(IllegalArgumentException.class);
-    BinTools.hex2bin(s);
+    BinTools.hex2bin("foo");
   }
 
   @Test
-  public void hex2binInputAOutputPositive() {
-    Assert.assertEquals(10, BinTools.hex2bin('A'));
+  public void hex2binCharacterInputOutputPositive() {
+    assertThat(BinTools.hex2bin('A')).isEqualTo(10);
   }
 
   @Test
-  public void hex2binInputNotNullOutputIllegalArgumentException2() {
+  public void hex2binInvalidInputOutputIllegalArgumentException() {
     thrown.expect(IllegalArgumentException.class);
     BinTools.hex2bin('\u013c');
-  }
-
-  @Test
-  public void hex2binInputNotNullOutputIllegalArgumentException() {
-    thrown.expect(IllegalArgumentException.class);
-    BinTools.hex2bin('\u0018');
   }
 }

--- a/src/test/java/net/lingala/zip4j/crypto/PBKDF2/BinToolsTest.java
+++ b/src/test/java/net/lingala/zip4j/crypto/PBKDF2/BinToolsTest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BinToolsTest {
 
   @Rule
-  public final ExpectedException thrown = ExpectedException.none();
+  public final ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void bin2hexForValidInputReturnsValidHex() {
@@ -29,13 +29,12 @@ public class BinToolsTest {
 
   @Test
   public void bin2hexForNullInputReturnsEmptyArray() {
-    final String s = null;
-    assertThat(BinTools.hex2bin(s)).isEqualTo(new byte[]{});
+    assertThat(BinTools.hex2bin(null)).isEqualTo(new byte[]{});
   }
 
   @Test
   public void hex2binForInvalidInputOutputIllegalArgumentException() {
-    thrown.expect(IllegalArgumentException.class);
+    expectedException.expect(IllegalArgumentException.class);
     BinTools.hex2bin("foo");
   }
 
@@ -46,7 +45,7 @@ public class BinToolsTest {
 
   @Test
   public void hex2binInvalidInputOutputIllegalArgumentException() {
-    thrown.expect(IllegalArgumentException.class);
+    expectedException.expect(IllegalArgumentException.class);
     BinTools.hex2bin('\u013c');
   }
 }


### PR DESCRIPTION
Hi,

I've analysed your code base and noticed that `net.lingala.zip4j.crypto.PBKDF2.BinTools` is not fully tested.

I've written some tests that cover these classes with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests should help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other particular classes that you consider important.