### PR TITLE
Allow input folder structure to be retained in zip file

### DIFF
--- a/src/main/java/net/lingala/zip4j/model/ZipParameters.java
+++ b/src/main/java/net/lingala/zip4j/model/ZipParameters.java
@@ -41,6 +41,7 @@ public class ZipParameters {
   private boolean writeExtendedLocalFileHeader = true;
   private boolean overrideExistingFilesInZip = true;
   private String rootFolderNameInZip;
+  private boolean useInputFolderPathInZip = false;
 
   public ZipParameters() {
   }
@@ -63,6 +64,7 @@ public class ZipParameters {
     this.writeExtendedLocalFileHeader = zipParameters.isWriteExtendedLocalFileHeader();
     this.overrideExistingFilesInZip = zipParameters.isOverrideExistingFilesInZip();
     this.rootFolderNameInZip = zipParameters.getRootFolderNameInZip();
+    this.useInputFolderPathInZip = zipParameters.getUseInputFolderPathInZip();
   }
 
   public CompressionMethod getCompressionMethod() {
@@ -207,5 +209,13 @@ public class ZipParameters {
 
   public void setRootFolderNameInZip(String rootFolderNameInZip) {
     this.rootFolderNameInZip = rootFolderNameInZip;
+  }
+
+  public boolean getUseInputFolderPathInZip() {
+    return useInputFolderPathInZip;
+  }
+
+  public void setUseInputFolderPathInZip(boolean useInputFolderPathInZip) {
+    this.useInputFolderPathInZip = useInputFolderPathInZip;
   }
 }

--- a/src/main/java/net/lingala/zip4j/tasks/AbstractAddFileToZipTask.java
+++ b/src/main/java/net/lingala/zip4j/tasks/AbstractAddFileToZipTask.java
@@ -103,7 +103,7 @@ public abstract class AbstractAddFileToZipTask<T> extends AsyncZipTask<T> {
       //If an entry already exists, we have to remove that entry first and then add content again.
       //In this case, add corresponding work
       String relativeFileName = getRelativeFileName(fileToAdd.getAbsolutePath(), zipParameters.getDefaultFolderPath(),
-          zipParameters.getRootFolderNameInZip());
+          zipParameters.getRootFolderNameInZip(), zipParameters.getUseInputFolderPathInZip());
       FileHeader fileHeader = getFileHeader(getZipModel(), relativeFileName);
       if (fileHeader != null) {
         totalWork += (getZipModel().getZipFile().length() - fileHeader.getCompressedSize());
@@ -166,7 +166,7 @@ public abstract class AbstractAddFileToZipTask<T> extends AsyncZipTask<T> {
 
     if (!Zip4jUtil.isStringNotNullAndNotEmpty(zipParameters.getFileNameInZip())) {
       String relativeFileName = getRelativeFileName(fileToAdd.getAbsolutePath(), zipParameters.getDefaultFolderPath(),
-          zipParameters.getRootFolderNameInZip());
+          zipParameters.getRootFolderNameInZip(), zipParameters.getUseInputFolderPathInZip());
       clonedZipParameters.setFileNameInZip(relativeFileName);
     }
 
@@ -199,7 +199,7 @@ public abstract class AbstractAddFileToZipTask<T> extends AsyncZipTask<T> {
 
     for (File file : files) {
       String fileName = getRelativeFileName(file.getAbsolutePath(), zipParameters.getDefaultFolderPath(),
-          zipParameters.getRootFolderNameInZip());
+          zipParameters.getRootFolderNameInZip(), zipParameters.getUseInputFolderPathInZip());
 
       FileHeader fileHeader = getFileHeader(zipModel, fileName);
       if (fileHeader != null) {

--- a/src/main/java/net/lingala/zip4j/util/FileUtils.java
+++ b/src/main/java/net/lingala/zip4j/util/FileUtils.java
@@ -181,7 +181,7 @@ public class FileUtils {
     return splitZipFiles;
   }
 
-  public static String getRelativeFileName(String file, String rootFolderPath, String rootFolderNameInZip)
+  public static String getRelativeFileName(String file, String rootFolderPath, String rootFolderNameInZip, boolean useInputPathInZip)
       throws ZipException {
 
     String fileName;
@@ -214,10 +214,13 @@ public class FileUtils {
         fileName = tmpFileName;
       } else {
         File relFile = new File(fileCanonicalPath);
+        fileName = useInputPathInZip ? fileCanonicalPath : relFile.getName();
         if (relFile.isDirectory()) {
-          fileName = relFile.getName() + ZIP_FILE_SEPARATOR;
-        } else {
-          fileName = relFile.getName();
+          fileName += ZIP_FILE_SEPARATOR;
+        }
+        if ((useInputPathInZip) &&
+            (fileName.startsWith("\\") || fileName.startsWith("/"))) {
+          fileName = fileName.substring(1);
         }
       }
     } catch (IOException e) {

--- a/src/test/java/net/lingala/zip4j/util/FileUtilsTest.java
+++ b/src/test/java/net/lingala/zip4j/util/FileUtilsTest.java
@@ -248,26 +248,26 @@ public class FileUtilsTest {
 
   @Test
   public void testGetRelativeFileNameWhenRootFoldersAreNull() throws ZipException {
-    assertThat(FileUtils.getRelativeFileName("somefile.txt", null, null)).isEqualTo("somefile.txt");
+    assertThat(FileUtils.getRelativeFileName("somefile.txt", null, null, false)).isEqualTo("somefile.txt");
   }
 
   @Test
   public void testGetRelativeFileWithRootFolderNameInZip() throws ZipException {
     String expectedRootFolder = "rootfolder" + InternalZipConstants.FILE_SEPARATOR + "somefile.txt";
-    assertThat(FileUtils.getRelativeFileName("somefile.txt", null, "rootfolder")).isEqualTo(expectedRootFolder);
+    assertThat(FileUtils.getRelativeFileName("somefile.txt", null, "rootfolder", false)).isEqualTo(expectedRootFolder);
   }
 
   @Test
   public void testGetRelativeFileWithRootFolderNameInZipWithFileSeparator() throws ZipException {
     String expectedRootFolder = "rootfolder" + InternalZipConstants.FILE_SEPARATOR + "somefile.txt";
-    assertThat(FileUtils.getRelativeFileName("somefile.txt", null, "rootfolder" + File.separator))
+    assertThat(FileUtils.getRelativeFileName("somefile.txt", null, "rootfolder" + File.separator, false))
         .isEqualTo(expectedRootFolder);
   }
 
   @Test
   public void testGetRelativeFileWithRootFolderNameInZipWithSeparatorsInName() throws ZipException {
     String expectedRootFolder = "rootfolder" + InternalZipConstants.FILE_SEPARATOR + "somefile.txt";
-    assertThat(FileUtils.getRelativeFileName("somefile.txt", null, "rootfolder\\")).isEqualTo(expectedRootFolder);
+    assertThat(FileUtils.getRelativeFileName("somefile.txt", null, "rootfolder\\", false)).isEqualTo(expectedRootFolder);
   }
 
   @Test


### PR DESCRIPTION
I wanted to be able to create a zip that contained files from multiple different folder locations and keep this folder structure in the zip file along with using split zip functionality to keep the zip files under 4GB.  This functionality can be enabled by setting the new ZipParameter useInputFolderPathInZip to true.

