### PR TITLE
Add offset support to readLongLittleEndian when reading from small array

### DIFF
--- a/src/main/java/net/lingala/zip4j/util/RawIO.java
+++ b/src/main/java/net/lingala/zip4j/util/RawIO.java
@@ -52,10 +52,10 @@ public class RawIO {
   }
 
   public long readLongLittleEndian(byte[] array, int pos) {
-    if (array.length < 8) {
+    if (array.length - pos < 8) {
       resetBytes(longBuff);
     }
-    System.arraycopy(array, pos, longBuff, 0, array.length < 8 ? array.length : 8);
+    System.arraycopy(array, pos, longBuff, 0, array.length < 8 ? array.length - pos : 8);
 
     long temp = 0;
     temp |= longBuff[7] & 0xff;

--- a/src/test/java/net/lingala/zip4j/util/RawIOIT.java
+++ b/src/test/java/net/lingala/zip4j/util/RawIOIT.java
@@ -69,6 +69,22 @@ public class RawIOIT extends AbstractIT {
   }
 
   @Test
+  public void testReadLongLitteEndianWithByteArrayAndOffset() {
+    byte[] b = new byte[9];
+    rawIO.writeLongLittleEndian(b, 1, 3463463735346821298L);
+
+    assertThat(rawIO.readLongLittleEndian(b, 1)).isEqualTo(3463463735346821298L);
+  }
+
+  @Test
+  public void testReadLongLittleEndianWithSmallByteArrayAndOffset() {
+    byte[] b = new byte[5];
+    rawIO.writeIntLittleEndian(b, 1, 234233);
+
+    assertThat(rawIO.readLongLittleEndian(b, 1)).isEqualTo(234233);
+  }
+
+  @Test
   public void testReadIntLittleEndianWithRandomAccessFile() throws IOException {
     try(RandomAccessFile randomAccessFile = new RandomAccessFile(fileToTest, RandomAccessFileMode.READ.getValue())) {
       randomAccessFile.seek(16);


### PR DESCRIPTION
Not sure if bug or feature, but I noticed that the `RawIO#readLongLittleEndian` method does support reading long values from arrays smaller than 8 bytes by adding `0`s and it also supports reading long values from an (at least 8 byte length) array with a given offset. However using both features together (reading with an offset from an array smaller than `offset + 8`) resulted in an exception.

I added two small tests for the offset feature (`testReadLongLitteEndianWithByteArrayAndOffset` succeded while `testReadLongLittleEndianWithSmallByteArrayAndOffset` failed) and tried to "fix" the read method to make its behavior more consistent.