### PR TITLE
Add unixMode to ZipParameters copy constructor

### DIFF
--- a/src/main/java/net/lingala/zip4j/model/ZipParameters.java
+++ b/src/main/java/net/lingala/zip4j/model/ZipParameters.java
@@ -101,6 +101,7 @@ public class ZipParameters {
     this.rootFolderNameInZip = zipParameters.getRootFolderNameInZip();
     this.fileComment = zipParameters.getFileComment();
     this.symbolicLinkAction = zipParameters.getSymbolicLinkAction();
+    this.unixMode = zipParameters.isUnixMode();
   }
 
   /**


### PR DESCRIPTION
Noticed that the parameters passed into `ZipFile.addFile` were losing the unix mode setting between setting it and `FileHeaderFactory.generateFileHeader`. `AbstractAddFileToZipTask.cloneAndAdjustZipParameters` was calling the copy constructor but the copy constructor didn't include the new `unixMode` field.