### PR TITLE
Support zipping symlinks that point to non-existent files

### DIFF
--- a/src/main/java/net/lingala/zip4j/tasks/AbstractAddFileToZipTask.java
+++ b/src/main/java/net/lingala/zip4j/tasks/AbstractAddFileToZipTask.java
@@ -1,5 +1,6 @@
 package net.lingala.zip4j.tasks;
 
+import java.nio.file.Files;
 import net.lingala.zip4j.exception.ZipException;
 import net.lingala.zip4j.headers.HeaderUtil;
 import net.lingala.zip4j.headers.HeaderWriter;
@@ -95,7 +96,7 @@ public abstract class AbstractAddFileToZipTask<T> extends AsyncZipTask<T> {
 
     zipOutputStream.putNextEntry(clonedZipParameters);
 
-    String symLinkTarget = fileToAdd.toPath().toRealPath().toString();
+    String symLinkTarget = Files.readSymbolicLink(fileToAdd.toPath()).toString();
     zipOutputStream.write(symLinkTarget.getBytes());
 
     closeEntry(zipOutputStream, splitOutputStream, fileToAdd, true);


### PR DESCRIPTION
I ran into an issue where zip4j threw an Exception trying to zip a directory that had a symlink to a file that didn't exist. Since I don't control the directory contents (it's a vendored dependency) I was hoping you'd accept this patch that adds the broken symlink as is to the zip if you specify `ZipParameters.SymbolicLinkAction.INCLUDE_LINK_ONLY`.