### PR TITLE
Trim redundancy code

### DIFF
--- a/src/main/java/net/lingala/zip4j/headers/HeaderReader.java
+++ b/src/main/java/net/lingala/zip4j/headers/HeaderReader.java
@@ -140,14 +140,7 @@ public class HeaderReader {
 
     long offSetStartCentralDir = HeaderUtil.getOffsetStartOfCentralDirectory(zipModel);
     long centralDirEntryCount = getNumberOfEntriesInCentralDirectory(zipModel);
-
-    if (zipModel.isZip64Format()) {
-      offSetStartCentralDir = zipModel.getZip64EndOfCentralDirectoryRecord()
-          .getOffsetStartCentralDirectoryWRTStartDiskNumber();
-      centralDirEntryCount = (int) zipModel.getZip64EndOfCentralDirectoryRecord()
-          .getTotalNumberOfEntriesInCentralDirectory();
-    }
-
+    
     zip4jRaf.seek(offSetStartCentralDir);
 
     byte[] shortBuff = new byte[2];


### PR DESCRIPTION
The ZIP64 checking has already done in `getOffsetCentralDirectory()` and `getNumberOfEntriesInCentralDirectory()`, so that here could use `offSetStartCentralDir` and `centralDirEntryCount` directly.