### PR TITLE
Convert to module and version up 2.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.lingala.zip4j</groupId>
     <artifactId>zip4j</artifactId>
-    <version>2.6.2-SNAPSHOT</version>
+    <version>2.6.2</version>
 
     <name>Zip4j</name>
     <description>Zip4j - A Java library for zip files and streams</description>
@@ -29,8 +29,8 @@
     </licenses>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <junit.version>4.12</junit.version>
         <lombok.version>1.18.8</lombok.version>
         <assertj.version>3.12.2</assertj.version>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,4 @@
+module net.lingala.zip4j {
+    exports net.lingala.zip4j;
+    exports net.lingala.zip4j.exception;
+}


### PR DESCRIPTION
I dont know if you are interested in this pull request, but I needed it for my [jrmapi](https://github.com/jlarriba/jrmapi) library. It converts zip4j into a module, with the drawback that, of course, it cannot be compiled anymore with Java 1.8.

It is a really big change, so feel free to close this PR if moving out of 1.8 is not in your scope.