### PR TITLE
Ignore files which no longer exist

### DIFF
--- a/src/main/java/net/lingala/zip4j/tasks/AbstractAddFileToZipTask.java
+++ b/src/main/java/net/lingala/zip4j/tasks/AbstractAddFileToZipTask.java
@@ -107,7 +107,7 @@ public abstract class AbstractAddFileToZipTask<T> extends AsyncZipTask<T> {
 
     zipOutputStream.putNextEntry(zipParameters);
 
-    if (!fileToAdd.isDirectory()) {
+    if (fileToAdd.exists() && !fileToAdd.isDirectory()) {
       try (InputStream inputStream = new FileInputStream(fileToAdd)) {
         while ((readLen = inputStream.read(readBuff)) != -1) {
           zipOutputStream.write(readBuff, 0, readLen);


### PR DESCRIPTION
This is especially important when adding a folder. If a file gets deleted during the zip process in the folder, the task will always continue