### PR TITLE
Updated ZipInputStream to throw ZipException for Strong Encryption

### DIFF
--- a/src/main/java/net/lingala/zip4j/exception/ZipException.java
+++ b/src/main/java/net/lingala/zip4j/exception/ZipException.java
@@ -56,6 +56,7 @@ public class ZipException extends IOException {
     CHECKSUM_MISMATCH,
     UNKNOWN_COMPRESSION_METHOD,
     FILE_NOT_FOUND,
+    UNSUPPORTED_ENCRYPTION,
     UNKNOWN
   }
 }

--- a/src/main/java/net/lingala/zip4j/io/inputstream/ZipInputStream.java
+++ b/src/main/java/net/lingala/zip4j/io/inputstream/ZipInputStream.java
@@ -194,8 +194,11 @@ public class ZipInputStream extends InputStream {
 
     if (localFileHeader.getEncryptionMethod() == EncryptionMethod.AES) {
       return new AesCipherInputStream(zipEntryInputStream, localFileHeader, password);
-    } else {
+    } else if (localFileHeader.getEncryptionMethod() == EncryptionMethod.ZIP_STANDARD) {
       return new ZipStandardCipherInputStream(zipEntryInputStream, localFileHeader, password);
+    } else {
+      final String message = String.format("Entry [%s] Strong Encryption not supported", localFileHeader.getFileName());
+      throw new ZipException(message, ZipException.Type.UNSUPPORTED_ENCRYPTION);
     }
   }
 

--- a/src/test/java/net/lingala/zip4j/io/inputstream/ZipInputStreamIT.java
+++ b/src/test/java/net/lingala/zip4j/io/inputstream/ZipInputStreamIT.java
@@ -2,6 +2,7 @@ package net.lingala.zip4j.io.inputstream;
 
 import net.lingala.zip4j.AbstractIT;
 import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
 import net.lingala.zip4j.model.LocalFileHeader;
 import net.lingala.zip4j.model.ZipParameters;
 import net.lingala.zip4j.model.enums.AesKeyStrength;
@@ -9,7 +10,9 @@ import net.lingala.zip4j.model.enums.AesVersion;
 import net.lingala.zip4j.model.enums.CompressionMethod;
 import net.lingala.zip4j.model.enums.EncryptionMethod;
 import net.lingala.zip4j.util.InternalZipConstants;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -26,6 +29,9 @@ import static net.lingala.zip4j.testutils.ZipFileVerifier.verifyFileContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ZipInputStreamIT extends AbstractIT {
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void testExtractStoreWithoutEncryption() throws IOException {
@@ -196,6 +202,17 @@ public class ZipInputStreamIT extends AbstractIT {
       while (zipInputStream.getNextEntry() != null) {
         zipInputStream.read(b);
       }
+    }
+  }
+
+  @Test
+  public void testExtractZipStrongEncryptionThrowsException() throws IOException {
+    expectedException.expect(ZipException.class);
+    expectedException.expectMessage("Entry [test.txt] Strong Encryption not supported");
+
+    File strongEncryptionFile = getTestArchiveFromResources("strong_encrypted.zip");
+    try (ZipInputStream zipInputStream = new ZipInputStream(new FileInputStream(strongEncryptionFile))) {
+      zipInputStream.getNextEntry();
     }
   }
 


### PR DESCRIPTION
The current ZipInputStream throws a ZipException in verifyCrc() when attempting to read an entry encrypted with the patented strong encryption algorithm.  This PR brings ZipInputStream in line with the recent updates to AbstractExtractFileTask described in #228 and throws a ZipException when encountering the strong encryption algorithm in initializeCipherInputStream().