### PR TITLE
Refactored duplicated AES methods to AesCipherUtil

### DIFF
--- a/src/main/java/net/lingala/zip4j/crypto/AesCipherUtil.java
+++ b/src/main/java/net/lingala/zip4j/crypto/AesCipherUtil.java
@@ -1,6 +1,89 @@
 package net.lingala.zip4j.crypto;
 
+import net.lingala.zip4j.crypto.PBKDF2.MacBasedPRF;
+import net.lingala.zip4j.crypto.PBKDF2.PBKDF2Engine;
+import net.lingala.zip4j.crypto.PBKDF2.PBKDF2Parameters;
+import net.lingala.zip4j.crypto.engine.AESEngine;
+import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.model.enums.AesKeyStrength;
+
+import static net.lingala.zip4j.util.InternalZipConstants.AES_HASH_CHARSET;
+import static net.lingala.zip4j.util.InternalZipConstants.AES_HASH_ITERATIONS;
+import static net.lingala.zip4j.util.InternalZipConstants.AES_MAC_ALGORITHM;
+import static net.lingala.zip4j.util.InternalZipConstants.AES_PASSWORD_VERIFIER_LENGTH;
+
 public class AesCipherUtil {
+  private static final int START_INDEX = 0;
+
+  /**
+   * Derive Password-Based Key for AES according to AE-1 and AE-2 Specifications
+   *
+   * @param salt Salt used for PBKDF2
+   * @param password Password used for PBKDF2 containing characters matching ISO-8859-1 character set
+   * @param aesKeyStrength Requested AES Key and MAC Strength
+   * @return Derived Password-Based Key
+   * @throws ZipException Thrown when Derived Key is not valid
+   */
+  public static byte[] derivePasswordBasedKey(final byte[] salt, final char[] password, final AesKeyStrength aesKeyStrength) throws ZipException {
+    final PBKDF2Parameters parameters = new PBKDF2Parameters(AES_MAC_ALGORITHM, AES_HASH_CHARSET, salt, AES_HASH_ITERATIONS);
+    final PBKDF2Engine engine = new PBKDF2Engine(parameters);
+
+    final int keyLength = aesKeyStrength.getKeyLength();
+    final int macLength = aesKeyStrength.getMacLength();
+    final int derivedKeyLength = keyLength + macLength + AES_PASSWORD_VERIFIER_LENGTH;
+    final byte[] derivedKey = engine.deriveKey(password, derivedKeyLength);
+    if (derivedKey != null && derivedKey.length == derivedKeyLength) {
+      return derivedKey;
+    } else {
+      final String message = String.format("Derived Key invalid for Key Length [%d] MAC Length [%d]", keyLength, macLength);
+      throw new ZipException(message);
+    }
+  }
+
+  /**
+   * Derive Password Verifier using Derived Key and requested AES Key Strength
+   *
+   * @param derivedKey Derived Key
+   * @param aesKeyStrength AES Key Strength
+   * @return Derived Password Verifier
+   */
+  public static byte[] derivePasswordVerifier(final byte[] derivedKey, final AesKeyStrength aesKeyStrength) {
+    byte[] derivedPasswordVerifier = new byte[AES_PASSWORD_VERIFIER_LENGTH];
+    final int keyMacLength = aesKeyStrength.getKeyLength() + aesKeyStrength.getMacLength();
+    System.arraycopy(derivedKey, keyMacLength, derivedPasswordVerifier, START_INDEX, AES_PASSWORD_VERIFIER_LENGTH);
+    return derivedPasswordVerifier;
+  }
+
+  /**
+   * Get MAC-Based PRF using default HMAC Algorithm defined in AE-1 and AE-2 Specification
+   *
+   * @param derivedKey Derived Key
+   * @param aesKeyStrength AES Key Strength
+   * @return Initialized MAC-Based PRF
+   */
+  public static MacBasedPRF getMacBasedPRF(final byte[] derivedKey, final AesKeyStrength aesKeyStrength) {
+    final int macLength = aesKeyStrength.getMacLength();
+    final byte[] macKey = new byte[macLength];
+    System.arraycopy(derivedKey, aesKeyStrength.getKeyLength(), macKey, START_INDEX, macLength);
+    final MacBasedPRF macBasedPRF = new MacBasedPRF(AES_MAC_ALGORITHM);
+    macBasedPRF.init(macKey);
+    return macBasedPRF;
+  }
+
+  /**
+   * Get AES Engine using derived key and requested AES Key Strength
+   *
+   * @param derivedKey Derived Key
+   * @param aesKeyStrength AES Key Strength
+   * @return AES Engine configured with AES Key
+   * @throws ZipException Thrown on AESEngine initialization failures
+   */
+  public static AESEngine getAESEngine(final byte[] derivedKey, final AesKeyStrength aesKeyStrength) throws ZipException {
+    final int keyLength = aesKeyStrength.getKeyLength();
+    final byte[] aesKey = new byte[keyLength];
+    System.arraycopy(derivedKey, START_INDEX, aesKey, START_INDEX, keyLength);
+    return new AESEngine(aesKey);
+  }
 
   public static void prepareBuffAESIVBytes(byte[] buff, int nonce) {
     buff[0] = (byte) nonce;

--- a/src/main/java/net/lingala/zip4j/io/inputstream/ZipInputStream.java
+++ b/src/main/java/net/lingala/zip4j/io/inputstream/ZipInputStream.java
@@ -290,7 +290,7 @@ public class ZipInputStream extends InputStream {
     }
 
     if (localFileHeader.getEncryptionMethod().equals(EncryptionMethod.AES)) {
-      return InternalZipConstants.AES_AUTH_LENGTH + AESDecrypter.PASSWORD_VERIFIER_LENGTH
+      return InternalZipConstants.AES_AUTH_LENGTH + InternalZipConstants.AES_PASSWORD_VERIFIER_LENGTH
           + localFileHeader.getAesExtraDataRecord().getAesKeyStrength().getSaltLength();
     } else if (localFileHeader.getEncryptionMethod().equals(EncryptionMethod.ZIP_STANDARD)) {
       return InternalZipConstants.STD_DEC_HDR_SIZE;

--- a/src/main/java/net/lingala/zip4j/io/outputstream/AesCipherOutputStream.java
+++ b/src/main/java/net/lingala/zip4j/io/outputstream/AesCipherOutputStream.java
@@ -1,6 +1,6 @@
 package net.lingala.zip4j.io.outputstream;
 
-import net.lingala.zip4j.crypto.AESEncrpyter;
+import net.lingala.zip4j.crypto.AESEncrypter;
 import net.lingala.zip4j.exception.ZipException;
 import net.lingala.zip4j.model.ZipParameters;
 
@@ -9,7 +9,7 @@ import java.io.OutputStream;
 
 import static net.lingala.zip4j.util.InternalZipConstants.AES_BLOCK_SIZE;
 
-class AesCipherOutputStream extends CipherOutputStream<AESEncrpyter> {
+class AesCipherOutputStream extends CipherOutputStream<AESEncrypter> {
 
   private byte[] pendingBuffer = new byte[AES_BLOCK_SIZE];
   private int pendingBufferLength = 0;
@@ -19,13 +19,13 @@ class AesCipherOutputStream extends CipherOutputStream<AESEncrpyter> {
   }
 
   @Override
-  protected AESEncrpyter initializeEncrypter(OutputStream outputStream, ZipParameters zipParameters, char[] password) throws IOException, ZipException {
-    AESEncrpyter encrypter = new AESEncrpyter(password, zipParameters.getAesKeyStrength());
+  protected AESEncrypter initializeEncrypter(OutputStream outputStream, ZipParameters zipParameters, char[] password) throws IOException, ZipException {
+    AESEncrypter encrypter = new AESEncrypter(password, zipParameters.getAesKeyStrength());
     writeAesEncryptionHeaderData(encrypter);
     return encrypter;
   }
 
-  private void writeAesEncryptionHeaderData(AESEncrpyter encrypter) throws IOException {
+  private void writeAesEncryptionHeaderData(AESEncrypter encrypter) throws IOException {
     writeHeaders(encrypter.getSaltBytes());
     writeHeaders(encrypter.getDerivedPasswordVerifier());
   }

--- a/src/main/java/net/lingala/zip4j/util/InternalZipConstants.java
+++ b/src/main/java/net/lingala/zip4j/util/InternalZipConstants.java
@@ -32,6 +32,10 @@ public final class InternalZipConstants {
   public static final int AES_AUTH_LENGTH = 10;
   public static final int AES_BLOCK_SIZE = 16;
   public static final int AES_EXTRA_DATA_RECORD_SIZE = 11;
+  public static final String AES_MAC_ALGORITHM = "HmacSHA1";
+  public static final String AES_HASH_CHARSET = "ISO-8859-1";
+  public static final int AES_HASH_ITERATIONS = 1000;
+  public static final int AES_PASSWORD_VERIFIER_LENGTH = 2;
 
   public static final int MIN_SPLIT_LENGTH = 65536;
   public static final long ZIP_64_SIZE_LIMIT = 4294967295L;


### PR DESCRIPTION
The AesEncrypter and AesDecryptor classes contained duplicate code to perform standard operations for AES key and MAC derivation.  This PR moves shared variables for HMAC algorithm and hash iterations to InternalZipConstants and also refactors shared methods to AesCipherUtil, making the the implementation easier to follow.  Also corrected naming of AesEncrypter, which was named AesEncrpyter.

All existing unit tests and integration tests pass following these changes.