### PR TITLE
fix(HeaderReader.java): fix the bug about fileNameUTF8Encoded

### DIFF
--- a/src/main/java/net/lingala/zip4j/headers/HeaderReader.java
+++ b/src/main/java/net/lingala/zip4j/headers/HeaderReader.java
@@ -155,7 +155,7 @@ public class HeaderReader {
       zip4jRaf.readFully(generalPurposeFlags);
       fileHeader.setEncrypted(isBitSet(generalPurposeFlags[0], 0));
       fileHeader.setDataDescriptorExists(isBitSet(generalPurposeFlags[0], 3));
-      fileHeader.setFileNameUTF8Encoded(isBitSet(generalPurposeFlags[1], 3));
+      fileHeader.setFileNameUTF8Encoded(isBitSet(generalPurposeFlags[0], 3));
       fileHeader.setGeneralPurposeFlag(generalPurposeFlags.clone());
 
       fileHeader.setCompressionMethod(CompressionMethod.getCompressionMethodFromCode(rawIO.readShortLittleEndian(


### PR DESCRIPTION
If the encoding of file name is UTF-8, the generalPurposeFlags will be 1000 0000