### PR TITLE
Use case sensitive comparison for file headers

### DIFF
--- a/src/main/java/net/lingala/zip4j/headers/HeaderUtil.java
+++ b/src/main/java/net/lingala/zip4j/headers/HeaderUtil.java
@@ -118,7 +118,7 @@ public class HeaderUtil {
         continue;
       }
 
-      if (fileName.equalsIgnoreCase(fileNameForHdr)) {
+      if (fileName.equals(fileNameForHdr)) {
         return fileHeader;
       }
     }

--- a/src/test/java/net/lingala/zip4j/headers/HeaderUtilTest.java
+++ b/src/test/java/net/lingala/zip4j/headers/HeaderUtilTest.java
@@ -99,6 +99,29 @@ public class HeaderUtilTest {
   }
 
   @Test
+  public void testGetFileHeaderWithExactMatchCaseSensitive() throws ZipException {
+    final String lowerCaseFile = FILE_NAME.toLowerCase();
+    final String upperCaseFile = FILE_NAME.toUpperCase();
+    ZipModel zipModel = new ZipModel();
+    CentralDirectory centralDirectory = new CentralDirectory();
+    centralDirectory.setFileHeaders(Arrays.asList(
+            generateFileHeader(lowerCaseFile),
+            generateFileHeader(upperCaseFile)
+    ));
+    zipModel.setCentralDirectory(centralDirectory);
+
+    assertThat(centralDirectory.getFileHeaders()).hasSize(2);
+
+    FileHeader fileHeaderLower = HeaderUtil.getFileHeader(zipModel, lowerCaseFile);
+    assertThat(fileHeaderLower).isNotNull();
+    assertThat(fileHeaderLower.getFileName()).isEqualTo(lowerCaseFile);
+
+    FileHeader fileHeaderUpper = HeaderUtil.getFileHeader(zipModel, upperCaseFile);
+    assertThat(fileHeaderUpper).isNotNull();
+    assertThat(fileHeaderUpper.getFileName()).isEqualTo(upperCaseFile);
+  }
+
+  @Test
   public void testGetFileHeaderWithWindowsFileSeparator() throws ZipException {
     ZipModel zipModel = new ZipModel();
     CentralDirectory centralDirectory = new CentralDirectory();


### PR DESCRIPTION
Allow creating zip archives that contain multiple files that differ only by case sensitivity.

See #395 