### PR TITLE
ci: update github actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,15 +6,20 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+    contents: read
+
 jobs:
   build:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         java-version: '11'
         distribution: 'temurin'


### PR DESCRIPTION
This PR:

-   Bumps GitHub Actions to their latest major versions, which now use Node 16 internally instead of Node 12 (EOL, no longer receives security updates):
    -   Changelog for `actions/checkout` can be [found here](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
    -   Releases for `actions/setup-java` can be [found here](https://github.com/actions/setup-java/releases)
-   Declares the minimum permissions for CI workflows to run at the workflow level, following principle of least privilege; see [related GitHub security post](https://securitylab.github.com/research/github-actions-building-blocks/)
-   Removes Git credentials/SSH keys after checkout as a security precaution by setting `persist-credentials` to false, they are not used after the initial checkout
