### PR TITLE
Improve header performance

### DIFF
--- a/src/main/java/net/lingala/zip4j/headers/HeaderUtil.java
+++ b/src/main/java/net/lingala/zip4j/headers/HeaderUtil.java
@@ -19,13 +19,13 @@ public class HeaderUtil {
   public static FileHeader getFileHeader(ZipModel zipModel, String fileName) throws ZipException {
     FileHeader fileHeader = getFileHeaderWithExactMatch(zipModel, fileName);
 
-    if (fileHeader == null) {
-      fileName = fileName.replaceAll("\\\\", "/");
-      fileHeader = getFileHeaderWithExactMatch(zipModel, fileName);
+    String backslashReplaced;
+    if (fileHeader == null && !(backslashReplaced = fileName.replaceAll("\\\\", "/")).equals(fileName)) {
+      fileHeader = getFileHeaderWithExactMatch(zipModel, backslashReplaced);
 
-      if (fileHeader == null) {
-        fileName = fileName.replaceAll("/", "\\\\");
-        fileHeader = getFileHeaderWithExactMatch(zipModel, fileName);
+      String slashesReplaced;
+      if (fileHeader == null && !(slashesReplaced = backslashReplaced.replaceAll("/", "\\\\")).equals(backslashReplaced)) {
+        fileHeader = getFileHeaderWithExactMatch(zipModel, slashesReplaced);
       }
     }
 

--- a/src/main/java/net/lingala/zip4j/headers/HeaderUtil.java
+++ b/src/main/java/net/lingala/zip4j/headers/HeaderUtil.java
@@ -103,26 +103,10 @@ public class HeaderUtil {
           + fileName);
     }
 
-    if (zipModel.getCentralDirectory().getFileHeaders() == null) {
-      throw new ZipException("file Headers are null, cannot determine file header with exact match for fileName: "
-          + fileName);
-    }
-
-    if (zipModel.getCentralDirectory().getFileHeaders().size() == 0) {
+    if (zipModel.getCentralDirectory().getFileNameHeaderMap().isEmpty()) {
       return null;
     }
 
-    for (FileHeader fileHeader : zipModel.getCentralDirectory().getFileHeaders()) {
-      String fileNameForHdr = fileHeader.getFileName();
-      if (!isStringNotNullAndNotEmpty(fileNameForHdr)) {
-        continue;
-      }
-
-      if (fileName.equals(fileNameForHdr)) {
-        return fileHeader;
-      }
-    }
-
-    return null;
+    return zipModel.getCentralDirectory().getFileNameHeaderMap().get(fileName);
   }
 }

--- a/src/main/java/net/lingala/zip4j/io/outputstream/ZipOutputStream.java
+++ b/src/main/java/net/lingala/zip4j/io/outputstream/ZipOutputStream.java
@@ -130,7 +130,7 @@ public class ZipOutputStream extends OutputStream {
     }
 
     zipModel.getLocalFileHeaders().add(localFileHeader);
-    zipModel.getCentralDirectory().getFileHeaders().add(fileHeader);
+    zipModel.getCentralDirectory().add(fileHeader);
 
     if (localFileHeader.isDataDescriptorExists()) {
       headerWriter.writeExtendedLocalHeader(localFileHeader, countingOutputStream);

--- a/src/main/java/net/lingala/zip4j/model/CentralDirectory.java
+++ b/src/main/java/net/lingala/zip4j/model/CentralDirectory.java
@@ -17,19 +17,58 @@
 package net.lingala.zip4j.model;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+
+import static net.lingala.zip4j.util.Zip4jUtil.isStringNotNullAndNotEmpty;
 
 public class CentralDirectory {
 
   private List<FileHeader> fileHeaders = new ArrayList<>();
+  private HashMap<String, FileHeader> fileNameMap = new HashMap<>();
   private DigitalSignature digitalSignature = new DigitalSignature();
 
   public List<FileHeader> getFileHeaders() {
     return fileHeaders;
   }
 
+  public HashMap<String, FileHeader> getFileNameHeaderMap() {
+    return fileNameMap;
+  }
+
   public void setFileHeaders(List<FileHeader> fileHeaders) {
-    this.fileHeaders = fileHeaders;
+    if(fileHeaders != null) {
+      this.fileHeaders.clear();
+      fileNameMap.clear();
+      for(FileHeader header : fileHeaders) {
+        add(header);
+      }
+    }
+  }
+
+  public void add(FileHeader header) {
+    if(header != null) {
+      fileHeaders.add(header);
+      if(isStringNotNullAndNotEmpty(header.getFileName())) {
+        fileNameMap.put(header.getFileName(), header);
+      }
+    }
+  }
+
+  public boolean remove(FileHeader header) {
+    if(header != null) {
+      return fileNameMap.values().remove(header) && fileHeaders.remove(header);
+    }
+    return false;
+  }
+
+  public void rename(FileHeader header) {
+    if(header != null) {
+      fileNameMap.values().remove(header);
+      if(isStringNotNullAndNotEmpty(header.getFileName())) {
+        fileNameMap.put(header.getFileName(), header);
+      }
+    }
   }
 
   public DigitalSignature getDigitalSignature() {

--- a/src/main/java/net/lingala/zip4j/tasks/RemoveFilesFromZipTask.java
+++ b/src/main/java/net/lingala/zip4j/tasks/RemoveFilesFromZipTask.java
@@ -57,7 +57,7 @@ public class RemoveFilesFromZipTask extends AbstractModifyFileTask<RemoveFilesFr
         if (shouldEntryBeRemoved(fileHeader, entriesToRemove)) {
           updateHeaders(sortedFileHeaders, fileHeader, lengthOfCurrentEntry);
 
-          if (!zipModel.getCentralDirectory().getFileHeaders().remove(fileHeader)) {
+          if (!zipModel.getCentralDirectory().remove(fileHeader)) {
             throw new ZipException("Could not remove entry from list of central directory headers");
           }
 

--- a/src/main/java/net/lingala/zip4j/tasks/RenameFilesTask.java
+++ b/src/main/java/net/lingala/zip4j/tasks/RenameFilesTask.java
@@ -146,6 +146,7 @@ public class RenameFilesTask extends AbstractModifyFileTask<RenameFilesTask.Rena
 
     fileHeaderToBeChanged.setFileName(newFileName);
     fileHeaderToBeChanged.setFileNameLength(newFileNameBytes.length);
+    zipModel.getCentralDirectory().rename(fileHeaderToBeChanged);
 
     updateOffsetsForAllSubsequentFileHeaders(sortedFileHeaders, zipModel, fileHeaderToBeChanged, headersOffset);
 

--- a/src/test/java/net/lingala/zip4j/headers/HeaderUtilTest.java
+++ b/src/test/java/net/lingala/zip4j/headers/HeaderUtilTest.java
@@ -57,17 +57,14 @@ public class HeaderUtilTest {
   }
 
   @Test
-  public void testGetFileHeaderWithNullFileHeadersThrowsException() throws ZipException {
-    expectedException.expect(ZipException.class);
-    expectZipException("file Headers are null, cannot determine file header with exact match for fileName: "
-        + FILE_NAME);
-
+  public void testGetFileHeaderWithNullFileHeadersReturnsNull() throws ZipException {
     ZipModel zipModel = new ZipModel();
     CentralDirectory centralDirectory = new CentralDirectory();
     centralDirectory.setFileHeaders(null);
     zipModel.setCentralDirectory(centralDirectory);
 
     HeaderUtil.getFileHeader(zipModel, FILE_NAME);
+    assertThat(HeaderUtil.getFileHeader(zipModel, FILE_NAME)).isNull();
   }
 
   @Test


### PR DESCRIPTION
I have a use case for storing many tiny files using zip4j to pack and make them easier to backup and move around. Currently there are close to 100M files split across 256 archives by the first two nibbles of the file's SHA1. Periodic updates involve scanning a directory of loose files and appending them to existing archives using zip4j.ZipFile.addFiles().

Examining performance with VisualVM showed some hot spots that this PR aims to tweak and improve the performance of - notably: HeaderUtil.getFileHeaderWithExactMatch and HeaderReader.readCentralDirectory. 

23759d1074271eaf0c2165c73390effa99747e0e preempts calls to HeaderUtil.getFileHeaderWithExactMatch in HeaderUtil.getFileHeader if the replacement operation resulted in no change to the file name being looked up.

abab5190bf7d57888d506ea0b5fcf768059256df changes the logic to read the central directory in larger chunks - instead of each field being read using the RandomAccessFile interface, the fixed size portions of the header are read into a byte array and RawIO is used to deserialize the data into fields.

e10dce33449c5f8597cfbf283748d97fa4e05453 adds a HashMap of file names to perform lookups on instead of traversing the CentralDirectory fileHeaders list for each lookup.

Improvement is roughly 85% for ZipFile.isValidZipFile() and 40% for ZipFile.addFiles()

<details>
  <summary>VisualVM Trace</summary>
  
  May be tainted by ZFS caching.

Original logic, showing sample data for 122 archives processed
![Before](https://user-images.githubusercontent.com/6669567/181115051-d6d949cf-9282-48b9-a3d6-124dcb8591bd.png)

Modified logic, showing sample data for 225 archives processed
![After](https://user-images.githubusercontent.com/6669567/181115072-b82b8636-2d78-42cc-9a0a-f0d63eef9adc.png)

</details>

<details>
  <summary>Instrumented Log Output Sample</summary>
  

Testing was performed with identical data using ZFS snapshots to revert to original state.
"Zip opening time" represents the time for ZipFile.isValidZipFile() to return.
"Add time" represents the time for ZipFile.addFiles() to return.

VisualVM trace above does not represent this run, it was from a different date / dataset.

Original Logic
```
Looking in /mnt/test/loose/00
Adding 1648 files to /mnt/test/zip/00.zip
Archive filecount: 387130
Zip opening time: 7410
Add time: 55451
Files added: 1648
ms/f: 33

Looking in /mnt/test/loose/01
Adding 1588 files to /mnt/test/zip/01.zip
Archive filecount: 387458
Zip opening time: 7226
Add time: 51670
Files added: 1588
ms/f: 32

Looking in /mnt/test/loose/02
Adding 1646 files to /mnt/test/zip/02.zip
Archive filecount: 387135
Zip opening time: 7157
Add time: 53017
Files added: 1646
ms/f: 32

Looking in /mnt/test/loose/03
Adding 1637 files to /mnt/test/zip/03.zip
Archive filecount: 386631
Zip opening time: 7151
Add time: 52027
Files added: 1637
ms/f: 31
```

Modified Logic
```
Looking in /mnt/test/loose/00
Adding 1648 files to /mnt/test/zip/00.zip
Archive filecount: 387130
Zip opening time: 1337
Add time: 28924
Files added: 1648
ms/f: 17

Looking in /mnt/test/loose/01
Adding 1588 files to /mnt/test/zip/01.zip
Archive filecount: 387458
Zip opening time: 1137
Add time: 29550
Files added: 1588
ms/f: 18

Looking in /mnt/test/loose/02
Adding 1646 files to /mnt/test/zip/02.zip
Archive filecount: 387135
Zip opening time: 1134
Add time: 31182
Files added: 1646
ms/f: 18

Looking in /mnt/test/loose/03
Adding 1637 files to /mnt/test/zip/03.zip
Archive filecount: 386631
Zip opening time: 1123
Add time: 31958
Files added: 1637
ms/f: 19
```
</details>

References Used:
https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html
https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT


