### PR TITLE
Add module info via moditect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,32 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.2.2.Final</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>net.lingala.zip4j</name>
+                                    <exports>
+                                        net.lingala.zip4j;
+                                        net.lingala.zip4j.*;
+                                    </exports>
+                                </moduleInfo>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This adds a module info to the final jar using moditect.

This one file will be put under `META-INF/versions/9` and so won't be picked up by android. Everything else will continue to be compiled at source/release `7`.

This is needed for using this library in a jlinked image