### PR TITLE
Restrict entry names which resolve to output directory itself

### DIFF
--- a/src/main/java/net/lingala/zip4j/tasks/AbstractExtractFileTask.java
+++ b/src/main/java/net/lingala/zip4j/tasks/AbstractExtractFileTask.java
@@ -8,6 +8,7 @@ import net.lingala.zip4j.model.UnzipParameters;
 import net.lingala.zip4j.model.ZipModel;
 import net.lingala.zip4j.progress.ProgressMonitor;
 import net.lingala.zip4j.util.BitUtils;
+import net.lingala.zip4j.util.InternalZipConstants;
 import net.lingala.zip4j.util.UnzipUtil;
 import net.lingala.zip4j.util.Zip4jUtil;
 
@@ -47,9 +48,10 @@ public abstract class AbstractExtractFileTask<T> extends AsyncZipTask<T> {
     }
 
     File outputFile = determineOutputFile(fileHeader, outputPath, newFileName);
+    if (outputFile == null) {
+      return;
+    }
     progressMonitor.setFileName(outputFile.getAbsolutePath());
-
-    assertCanonicalPathsAreSame(outputFile, outputPath, fileHeader);
 
     verifyNextEntry(zipInputStream, fileHeader);
 
@@ -68,26 +70,6 @@ public abstract class AbstractExtractFileTask<T> extends AsyncZipTask<T> {
 
     if (!isSymbolicLink) {
       UnzipUtil.applyFileAttributes(fileHeader, outputFile);
-    }
-  }
-
-  private void assertCanonicalPathsAreSame(File outputFile, String outputPath, FileHeader fileHeader)
-      throws IOException {
-
-    String outputFileCanonicalPath = outputFile.getCanonicalPath();
-    if (outputFile.isDirectory() && !outputFileCanonicalPath.endsWith(FILE_SEPARATOR)) {
-      outputFileCanonicalPath = outputFileCanonicalPath + FILE_SEPARATOR;
-    }
-
-    String outputCanonicalPath = (new File(outputPath).getCanonicalPath());
-    if (!outputCanonicalPath.endsWith(FILE_SEPARATOR)) {
-      outputCanonicalPath += FILE_SEPARATOR;
-    }
-
-    // make sure no file is extracted outside the target directory (a.k.a. zip slip)
-    if (!outputFileCanonicalPath.startsWith(outputCanonicalPath)) {
-      throw new ZipException("illegal file name that breaks out of the target directory: "
-          + fileHeader.getFileName());
     }
   }
 
@@ -180,12 +162,58 @@ public abstract class AbstractExtractFileTask<T> extends AsyncZipTask<T> {
     }
   }
 
-  private File determineOutputFile(FileHeader fileHeader, String outputPath, String newFileName) {
+  /**
+   * Determines the resolved output file path inside the {@code outputPath} directory.
+   * The file name being used is either {@code newFileName} or if null or empty it is the entry name from the
+   * {@code fileHeader}.
+   *
+   * <p>An exception is thrown if the resolved file path escapes the output directory.
+   *
+   * @throws IOException if resolving the path fails, or if the path escapes the output directory
+   * @return the resolved file path, or {@code null} if the file should be skipped
+   */
+  private File determineOutputFile(FileHeader fileHeader, String outputPath, String newFileName) throws IOException {
     String outputFileName = fileHeader.getFileName();
     if (Zip4jUtil.isStringNotNullAndNotEmpty(newFileName)) {
       outputFileName = newFileName;
     }
-    return new File(outputPath, getFileNameWithSystemFileSeparators(outputFileName));
+    File outputFile = new File(outputPath, getFileNameWithSystemFileSeparators(outputFileName));
+
+    // Perform validation
+    {
+      String outputFileCanonicalPath = outputFile.getCanonicalPath();
+      // Appending FILE_SEPARATOR both for the output directory and the output file is necessary:
+      // - to detect Zip Slip into sibling directory with same prefix, e.g. `outdir-sibling/file.txt` instead of `outdir/`
+      // - on Windows because there are quirks where `getCanonicalPath()` for the same path can have a trailing slash
+      //   in one case and is missing it in another case, e.g. `new File(dir, " ").getCanonicalPath()` refers to the
+      //   same directory as `dir` but has an unexpected trailing '\'
+      if (outputFile.isDirectory() && !outputFileCanonicalPath.endsWith(FILE_SEPARATOR)) {
+        outputFileCanonicalPath += FILE_SEPARATOR;
+      }
+
+      String outputCanonicalPath = (new File(outputPath).getCanonicalPath());
+      if (!outputCanonicalPath.endsWith(FILE_SEPARATOR)) {
+        outputCanonicalPath += FILE_SEPARATOR;
+      }
+
+      // make sure no file is extracted outside the target directory (a.k.a. zip slip)
+      if (!outputFileCanonicalPath.startsWith(outputCanonicalPath)) {
+        throw new ZipException("illegal file name that breaks out of the target directory: "
+                + outputFileName);
+      }
+
+      if (outputFileCanonicalPath.equals(outputCanonicalPath)) {
+        // Assume a redundant `/` entry is non-malicious but skip processing it to avoid modifying output
+        // directory in some way (e.g. changing file permissions)
+        if (outputFileName.equals(InternalZipConstants.ZIP_FILE_SEPARATOR)) {
+          return null;
+        }
+
+        throw new ZipException("illegal file name that refers to output directory itself: " + outputFileName);
+      }
+    }
+
+    return outputFile;
   }
 
   private String getFileNameWithSystemFileSeparators(String fileNameToReplace) {

--- a/src/test/java/net/lingala/zip4j/MiscZipFileIT.java
+++ b/src/test/java/net/lingala/zip4j/MiscZipFileIT.java
@@ -31,6 +31,7 @@ import static net.lingala.zip4j.testutils.TestUtils.getFileNamesOfFiles;
 import static net.lingala.zip4j.testutils.TestUtils.getTestFileFromResources;
 import static net.lingala.zip4j.util.Zip4jUtil.epochToExtendedDosTime;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 public class MiscZipFileIT extends AbstractIT {
@@ -462,6 +463,84 @@ public class MiscZipFileIT extends AbstractIT {
     zipFile.addFiles(FILES_TO_ADD);
     zipFile.extractAll(new File(outputFolder.getPath(),
             ".." + InternalZipConstants.FILE_SEPARATOR + outputFolder.getName()).getAbsolutePath());
+  }
+
+  @Test
+  public void testZipSlipFileDotEntryIsRoot() throws IOException {
+    ZipFile zip = new ZipFile(generatedZipFile);
+
+    ZipParameters zipParameters = new ZipParameters();
+    zipParameters.setFileNameInZip(".");
+    zip.addFile(TestUtils.getTestFileFromResources("sample_text1.txt"), zipParameters);
+
+    assertThatThrownBy(() -> zip.extractAll(outputFolder.getAbsolutePath()))
+        .isInstanceOf(ZipException.class)
+        .hasMessage("illegal file name that refers to output directory itself: .");
+
+    // Output folder should not have been modified
+    assertThat(outputFolder).isEmptyDirectory();
+  }
+
+  @Test
+  public void testZipSlipFileEntryWithParentIsRoot() throws IOException {
+    ZipFile zip = new ZipFile(generatedZipFile);
+
+    ZipParameters zipParameters = new ZipParameters();
+    zipParameters.setFileNameInZip("file/..");
+    zip.addFile(TestUtils.getTestFileFromResources("sample_text1.txt"), zipParameters);
+
+    assertThatThrownBy(() -> zip.extractAll(outputFolder.getAbsolutePath()))
+        .isInstanceOf(ZipException.class)
+        .message().isIn(
+            "illegal file name that refers to output directory itself: file/..",
+            // On Linux `File#isDirectory()` is false for 'file/..', so this triggers the regular Zip Slip exception
+            "illegal file name that breaks out of the target directory: file/.."
+        );
+
+    // Output folder should not have been modified
+    assertThat(outputFolder).isEmptyDirectory();
+  }
+
+  @Test
+  public void testZipSlipDirEntryWithParentIsRoot() throws IOException {
+    ZipFile zip = new ZipFile(generatedZipFile);
+
+    ZipParameters zipParameters = new ZipParameters();
+    zipParameters.setFileNameInZip("dir/../");
+    File emptyFolder = temporaryFolder.newFolder();
+    zip.addFolder(emptyFolder, zipParameters);
+
+    assertThatThrownBy(() -> zip.extractAll(outputFolder.getAbsolutePath()))
+        .isInstanceOf(ZipException.class)
+        .message().isIn(
+            "illegal file name that refers to output directory itself: dir/../",
+            // On Linux `File#isDirectory()` is false for 'dir/../', so this triggers the regular Zip Slip exception
+            "illegal file name that breaks out of the target directory: dir/../"
+        );
+
+    // Output folder should not have been modified
+    assertThat(outputFolder).isEmptyDirectory();
+  }
+
+  /**
+   * Tests how a {@code '/'} entry is processed.
+   * It should simply be ignored, without causing any modifications (e.g. permission changes) to the output directory.
+   */
+  @Test
+  public void testRootDirEntry() throws IOException {
+    ZipFile zip = new ZipFile(generatedZipFile);
+
+    ZipParameters zipParameters = new ZipParameters();
+    zipParameters.setFileNameInZip("/");
+    File emptyFolder = temporaryFolder.newFolder();
+    zip.addFolder(emptyFolder, zipParameters);
+
+    // Note: Ideally also verify that file permissions cannot be changed, but cannot easily create a ZIP file
+    // here whose entry has custom file permissions
+    zip.extractAll(outputFolder.getPath());
+
+    // Output folder should not have been modified
+    assertThat(outputFolder).isEmptyDirectory();
   }
 
   @Test


### PR DESCRIPTION
When extracting a ZIP file with entries named `.`, `/` or similar, those entries refer to the output directory itself. This PR restricts these entry name to avoid modifications (such as file permission changes) to the output directory.

Here is a small sample which previously caused Zip4j to erroneously modify the permissions of the output directory. The example uses the Apache Commons Compress library to create the ZIP file because that library makes it a bit easier to set these ZIP entry attributes.
```java
import net.lingala.zip4j.ZipFile;
import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;

import java.nio.file.Files;
import java.nio.file.Path;
import java.util.Set;

class Zip4jPermissionsChange {
    public static void main(String[] args) throws Exception {
        Path zipPath = Path.of("permissions-change.zip");

        Path outputDir = Path.of("permissions-change");
        Files.deleteIfExists(outputDir);
        Files.createDirectory(outputDir);
        Files.setPosixFilePermissions(outputDir, Set.of());

        System.out.println("Permissions before: " + Files.getPosixFilePermissions(outputDir));

        createZip(zipPath);

        try (ZipFile zipFile = new ZipFile(zipPath.toFile())) {
            zipFile.extractAll(outputDir.toString());
        }

        System.out.println("Permissions after: " + Files.getPosixFilePermissions(outputDir));
    }

    public static void createZip(Path path) throws Exception {
        try (ZipArchiveOutputStream zipStream = new ZipArchiveOutputStream(path)) {
            var entry = new ZipArchiveEntry("/");
            // Set 'allow all' permissions
            entry.setUnixMode(0b1_1111_1111);
            zipStream.putArchiveEntry(entry);
            zipStream.closeArchiveEntry();
        }
    }
}
```